### PR TITLE
more generic broadcast for `AbstractBlockTuple`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockedtuple.jl
+++ b/src/blockedtuple.jl
@@ -151,8 +151,6 @@ function BlockArrays.blocks(bt::AbstractBlockTuple)
   return ntuple(i -> Tuple(bt)[bf[i]:bl[i]], blocklength(bt))
 end
 
-#    length(BlockLengths) != BlockLength && throw(DimensionMismatch("Invalid blocklength"))
-
 # =====================================  BlockedTuple  =====================================
 #
 struct BlockedTuple{BlockLength,BlockLengths,Flat} <: AbstractBlockTuple{BlockLength}

--- a/src/blockedtuple.jl
+++ b/src/blockedtuple.jl
@@ -23,7 +23,7 @@ end
 
 # Base interface
 Base.axes(bt::AbstractBlockTuple) = (blockedrange([blocklengths(bt)...]),)
-Base.axes(::AbstractBlockTuple{0}) = (blockedrange(zeros(Int, 0)),)
+Base.axes(::AbstractBlockTuple{0}) = (blockedrange(Int[]),)
 
 Base.deepcopy(bt::AbstractBlockTuple) = deepcopy.(bt)
 

--- a/src/blockedtuple.jl
+++ b/src/blockedtuple.jl
@@ -23,6 +23,7 @@ end
 
 # Base interface
 Base.axes(bt::AbstractBlockTuple) = (blockedrange([blocklengths(bt)...]),)
+Base.axes(::AbstractBlockTuple{0}) = (blockedrange(zeros(Int, 0)),)
 
 Base.deepcopy(bt::AbstractBlockTuple) = deepcopy.(bt)
 

--- a/src/blockedtuple.jl
+++ b/src/blockedtuple.jl
@@ -10,7 +10,7 @@ using TypeParameterAccessors: unspecify_type_parameters
 # ==================================  AbstractBlockTuple  ==================================
 #
 # AbstractBlockTuple imposes BlockLength as first type parameter for easy dispatch
-# it makes no assumotion on storage type
+# it makes no assumption on storage type
 abstract type AbstractBlockTuple{BlockLength} end
 
 constructorof(type::Type{<:AbstractBlockTuple}) = unspecify_type_parameters(type)
@@ -74,7 +74,6 @@ end
 # tuplemortar(((1,), (2,))) .== tuplemortar(((1,), (2,))) = tuplemortar(((true,), (true,)))
 # tuplemortar(((1,), (2,))) .== tuplemortar(((1, 2),)) = (true, true)
 # tuplemortar(((1,), (2,))) .== tuplemortar(((1,), (2,), (3,))) = error DimensionMismatch
-
 function Base.BroadcastStyle(
   ::AbstractBlockTupleBroadcastStyle, ::AbstractBlockTupleBroadcastStyle
 )

--- a/test/test_blockedpermutation.jl
+++ b/test/test_blockedpermutation.jl
@@ -77,6 +77,8 @@ using TensorAlgebra:
   @test (@constinferred BlockedTuple(p)) == bt
   @test (@constinferred map(identity, p)) == bt
   @test (@constinferred p .+ p) == tuplemortar(((6, 4), (), (2,)))
+  @test (@constinferred p .+ bt) == tuplemortar(((6, 4), (), (2,)))
+  @test (@constinferred bt .+ p) == tuplemortar(((6, 4), (), (2,)))
   @test (@constinferred blockedperm(p)) == p
   @test (@constinferred blockedperm(bt)) == p
 
@@ -149,6 +151,8 @@ end
   @test (@constinferred blocks(tp)) == blocks(bt)
   @test (@constinferred map(identity, tp)) == bt
   @test (@constinferred tp .+ tp) == tuplemortar(((2, 4), (), (6,)))
+  @test (@constinferred tp .+ Tuple(tp)) == tuplemortar(((2, 4), (), (6,)))
+  @test (@constinferred tp .+ BlockedTuple(tp)) == tuplemortar(((2, 4), (), (6,)))
   @test (@constinferred blockedperm(tp)) == tp
   @test (@constinferred trivialperm(tp)) == tp
   @test (@constinferred trivialperm(bt)) == tp

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -54,11 +54,35 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
     BlockedTuple{3,blocklengths(bt)}(Tuple(bt) .+ 1)
   @test (@constinferred bt .+ tuplemortar(((1,), (1, 1), (1, 1)))) ==
     BlockedTuple{3,blocklengths(bt)}(Tuple(bt) .+ 1)
-  @test_throws DimensionMismatch bt .+ tuplemortar(((1, 1), (1, 1), (1,)))
+  @test bt .+ tuplemortar(((1, 1), (1, 1), (1,))) isa NTuple{5,Int}
+  @test bt .+ tuplemortar(((1, 1), (1, 1), (1,))) == (2, 5, 3, 6, 4)
 
   bt = tuplemortar(((1:2, 1:2), (1:3,)))
   @test length.(bt) == tuplemortar(((2, 2), (3,)))
   @test length.(length.(bt)) == tuplemortar(((1, 1), (1,)))
+
+  bt = tuplemortar(((1,), (2,)))
+  @test (bt .== bt) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
+  @test (bt .== bt) == tuplemortar(((true,), (true,)))
+  @test (bt .== tuplemortar(((1, 2),))) isa Tuple{Bool,Bool}
+  @test (bt .== tuplemortar(((1, 2),))) == (true, true)
+  @test_throws DimensionMismatch bt .== tuplemortar(((1,), (2,), (3,)))
+  @test (bt .== (1, 2)) isa Tuple{Bool,Bool}
+  @test (bt .== (1, 2)) == (true, true)
+  @test_throws DimensionMismatch bt .== (1, 2, 3)
+  @test (bt .== 1) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
+  @test (bt .== 1) == tuplemortar(((true,), (false,)))
+  @test (bt .== [1, 1]) isa BlockVector{Bool}
+  @test blocks(bt .== [1, 1]) == [[true], [false]]
+  @test_throws DimensionMismatch bt .== [1, 2, 3]
+
+  @test ((1, 2) .== bt) isa Tuple{Bool,Bool}
+  @test ((1, 2) .== bt) == (true, true)
+  @test_throws DimensionMismatch (1, 2, 3) .== bt
+  @test (1 .== bt) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
+  @test (1 .== bt) == tuplemortar(((true,), (false,)))
+  @test ([1, 1] .== bt) isa BlockVector{Bool}
+  @test blocks([1, 1] .== bt) == [[true], [false]]
 
   # empty blocks
   bt = tuplemortar(((1,), (), (5, 3)))

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -1,4 +1,4 @@
-using Test: @test, @test_throws
+using Test: @test, @test_throws, @testset
 
 using BlockArrays:
   Block, BlockVector, blocklength, blocklengths, blockedrange, blockisequal, blocks
@@ -77,8 +77,9 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
   @test (@constinferred bt .== 1) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
   @test (bt .== 1) == tuplemortar(((true,), (false,)))
   @test (@constinferred bt .== (1,)) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
+
   @test (bt .== (1,)) == tuplemortar(((true,), (false,)))
-  @test_broken @inferred bt .== [1, 1]
+  # BlockedTuple .== AbstractVector is not type stable. Requires fix in BlockArrays
   @test (bt .== [1, 1]) isa BlockVector{Bool}
   @test blocks(bt .== [1, 1]) == [[true], [false]]
   @test_throws DimensionMismatch bt .== [1, 2, 3]
@@ -90,7 +91,6 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
   @test (1 .== bt) == tuplemortar(((true,), (false,)))
   @test (@constinferred (1,) .== bt) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
   @test ((1,) .== bt) == tuplemortar(((true,), (false,)))
-  @test_broken @inferred [1, 1] .== bt
   @test ([1, 1] .== bt) isa BlockVector{Bool}
   @test blocks([1, 1] .== bt) == [[true], [false]]
 

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -55,8 +55,10 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
     BlockedTuple{3,blocklengths(bt)}(Tuple(bt) .+ 1)
   @test (@constinferred bt .+ tuplemortar(((1,), (1, 1), (1, 1)))) ==
     BlockedTuple{3,blocklengths(bt)}(Tuple(bt) .+ 1)
-  @test bt .+ tuplemortar(((1, 1), (1, 1), (1,))) isa NTuple{5,Int}
-  @test bt .+ tuplemortar(((1, 1), (1, 1), (1,))) == (2, 5, 3, 6, 4)
+  @test (@constinferred bt .+ tuplemortar(((1,), (1, 1, 1), (1,)))) isa
+    BlockedTuple{4,(1, 2, 1, 1),NTuple{5,Int64}}
+  @test bt .+ tuplemortar(((1,), (1, 1, 1), (1,))) ==
+    tuplemortar(((2,), (5, 3), (6,), (4,)))
 
   bt = tuplemortar(((1:2, 1:2), (1:3,)))
   @test length.(bt) == tuplemortar(((2, 2), (3,)))
@@ -65,8 +67,8 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
   bt = tuplemortar(((1,), (2,)))
   @test (bt .== bt) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
   @test (bt .== bt) == tuplemortar(((true,), (true,)))
-  @test (bt .== tuplemortar(((1, 2),))) isa Tuple{Bool,Bool}
-  @test (bt .== tuplemortar(((1, 2),))) == (true, true)
+  @test (bt .== tuplemortar(((1, 2),))) isa BlockedTuple{2,(1, 1),Tuple{Bool,Bool}}
+  @test (bt .== tuplemortar(((1, 2),))) == tuplemortar(((true,), (true,)))
   @test_throws DimensionMismatch bt .== tuplemortar(((1,), (2,), (3,)))
   @test (bt .== (1, 2)) isa Tuple{Bool,Bool}
   @test (bt .== (1, 2)) == (true, true)

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -1,6 +1,7 @@
 using Test: @test, @test_throws
 
-using BlockArrays: Block, blocklength, blocklengths, blockedrange, blockisequal, blocks
+using BlockArrays:
+  Block, BlockVector, blocklength, blocklengths, blockedrange, blockisequal, blocks
 using TestExtras: @constinferred
 
 using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -93,16 +93,19 @@ using TensorAlgebra: BlockedTuple, blockeachindex, tuplemortar
   @test Tuple(bt) == (1, 5, 3)
   @test blocklengths(bt) == (1, 0, 2)
   @test (@constinferred blocks(bt)) == ((1,), (), (5, 3))
+  @test blockisequal(only(axes(bt)), blockedrange([1, 0, 2]))
 
   bt = tuplemortar(((), ()))
   @test bt isa BlockedTuple{2}
   @test Tuple(bt) == ()
   @test blocklengths(bt) == (0, 0)
   @test (@constinferred blocks(bt)) == ((), ())
+  @test blockisequal(only(axes(bt)), blockedrange([0, 0]))
 
   bt = tuplemortar(())
   @test bt isa BlockedTuple{0}
   @test Tuple(bt) == ()
   @test blocklengths(bt) == ()
   @test (@constinferred blocks(bt)) == ()
+  @test blockisequal(only(axes(bt)), blockedrange(zeros(Int, 0)))
 end


### PR DESCRIPTION
This PR generalizes broadcast for `AbstractBlockTuple`. It allows broadcast between an `AbstractBlockTuple` and
- another `AbstractBlockTuple` with same total length but different blocklengths
- a `Tuple` with same length
- a scalar
- an `AbstractVector` with same length