### PR TITLE
More matrix factorizations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -16,6 +16,8 @@ using MatrixAlgebraKit:
   eigh_vals!,
   left_orth,
   left_orth!,
+  left_polar,
+  left_polar!,
   lq_full,
   lq_full!,
   lq_compact,
@@ -26,6 +28,8 @@ using MatrixAlgebraKit:
   qr_compact!,
   right_orth,
   right_orth!,
+  right_polar,
+  right_polar!,
   svd_full,
   svd_full!,
   svd_compact,
@@ -91,14 +95,43 @@ for (svd, svd_trunc, svd_full, svd_compact) in (
   end
 end
 
-for (factorize, left_orth, right_orth) in
-    ((:factorize, :left_orth, :right_orth), (:factorize!, :left_orth!, :right_orth!))
+for (polar, left_polar, right_polar) in
+    ((:polar, :left_polar, :right_polar), (:polar!, :left_polar!, :right_polar!))
+  @eval begin
+    function $polar(A::AbstractMatrix; side=:left, kwargs...)
+      f = if side == :left
+        $left_polar
+      elseif side == :right
+        $right_polar
+      else
+        throw(ArgumentError("`side=$side` not supported."))
+      end
+      return f(A; kwargs...)
+    end
+  end
+end
+
+for (orth, left_orth, right_orth) in
+    ((:orth, :left_orth, :right_orth), (:orth!, :left_orth!, :right_orth!))
+  @eval begin
+    function $orth(A::AbstractMatrix; side=:left, kwargs...)
+      f = if side == :left
+        $left_orth
+      elseif side == :right
+        $right_orth
+      else
+        throw(ArgumentError("`side=$side` not supported."))
+      end
+      return f(A; kwargs...)
+    end
+  end
+end
+
+for (factorize, orth_f) in ((:factorize, :(MatrixAlgebra.orth)), (:factorize!, :orth!))
   @eval begin
     function $factorize(A::AbstractMatrix; orth=:left, kwargs...)
-      f = if orth == :left
-        $left_orth
-      elseif orth == :right
-        $right_orth
+      f = if orth in (:left, :right)
+        $orth_f
       else
         throw(ArgumentError("`orth=$orth` not supported."))
       end

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -1,0 +1,110 @@
+module MatrixAlgebra
+
+using LinearAlgebra: LinearAlgebra
+using MatrixAlgebraKit:
+  eig_full,
+  eig_full!,
+  eig_trunc,
+  eig_trunc!,
+  eig_vals,
+  eig_vals!,
+  eigh_full,
+  eigh_full!,
+  eigh_trunc,
+  eigh_trunc!,
+  eigh_vals,
+  eigh_vals!,
+  left_orth,
+  left_orth!,
+  lq_full,
+  lq_full!,
+  lq_compact,
+  lq_compact!,
+  qr_full,
+  qr_full!,
+  qr_compact,
+  qr_compact!,
+  right_orth,
+  right_orth!,
+  svd_full,
+  svd_full!,
+  svd_compact,
+  svd_compact!,
+  svd_trunc,
+  svd_trunc!
+
+for (f, f_full, f_compact) in (
+  (:qr, :qr_full, :qr_compact),
+  (:qr!, :qr_full!, :qr_compact!),
+  (:lq, :lq_full, :lq_compact),
+  (:lq!, :lq_full!, :lq_compact!),
+)
+  @eval begin
+    function $f(A::AbstractMatrix; full::Bool=false, kwargs...)
+      f = full ? $f_full : $f_compact
+      return f(A; kwargs...)
+    end
+  end
+end
+
+for (eigen, eigh_full, eig_full, eigh_trunc, eig_trunc) in (
+  (:eigen, :eigh_full, :eig_full, :eigh_trunc, :eig_trunc),
+  (:eigen!, :eigh_full!, :eig_full!, :eigh_trunc!, :eig_trunc!),
+)
+  @eval begin
+    function $eigen(A::AbstractMatrix; trunc=nothing, ishermitian=nothing, kwargs...)
+      ishermitian = @something ishermitian LinearAlgebra.ishermitian(A)
+      f = if !isnothing(trunc)
+        ishermitian ? $eigh_trunc : $eig_trunc
+      else
+        ishermitian ? $eigh_full : $eig_full
+      end
+      return f(A; kwargs...)
+    end
+  end
+end
+
+for (eigvals, eigh_vals, eig_vals) in
+    ((:eigvals, :eigh_vals, :eig_vals), (:eigvals!, :eigh_vals!, :eig_vals!))
+  @eval begin
+    function $eigvals(A::AbstractMatrix; ishermitian=nothing, kwargs...)
+      ishermitian = @something ishermitian LinearAlgebra.ishermitian(A)
+      f = (ishermitian ? $eigh_vals : $eig_vals)
+      return f(A; kwargs...)
+    end
+  end
+end
+
+for (svd, svd_trunc, svd_full, svd_compact) in (
+  (:svd, :svd_trunc, :svd_full, :svd_compact),
+  (:svd!, :svd_trunc!, :svd_full!, :svd_compact!),
+)
+  @eval begin
+    function $svd(A::AbstractMatrix; full::Bool=false, trunc=nothing, kwargs...)
+      return if !isnothing(trunc)
+        @assert !full "Specified both full and truncation, currently not supported"
+        $svd_trunc(A; trunc, kwargs...)
+      else
+        (full ? $svd_full : $svd_compact)(A; kwargs...)
+      end
+    end
+  end
+end
+
+for (factorize, left_orth, right_orth) in
+    ((:factorize, :left_orth, :right_orth), (:factorize!, :left_orth!, :right_orth!))
+  @eval begin
+    function $factorize(A::AbstractMatrix; orth=:left, kwargs...)
+      f = if orth == :left
+        $left_orth
+      elseif orth == :right
+        $right_orth
+      else
+        throw(ArgumentError("`orth=$orth` not supported."))
+      end
+      return f(A; kwargs...)
+    end
+  end
+end
+
+end

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -1,41 +1,7 @@
 module MatrixAlgebra
 
 using LinearAlgebra: LinearAlgebra
-using MatrixAlgebraKit:
-  eig_full,
-  eig_full!,
-  eig_trunc,
-  eig_trunc!,
-  eig_vals,
-  eig_vals!,
-  eigh_full,
-  eigh_full!,
-  eigh_trunc,
-  eigh_trunc!,
-  eigh_vals,
-  eigh_vals!,
-  left_orth,
-  left_orth!,
-  left_polar,
-  left_polar!,
-  lq_full,
-  lq_full!,
-  lq_compact,
-  lq_compact!,
-  qr_full,
-  qr_full!,
-  qr_compact,
-  qr_compact!,
-  right_orth,
-  right_orth!,
-  right_polar,
-  right_polar!,
-  svd_full,
-  svd_full!,
-  svd_compact,
-  svd_compact!,
-  svd_trunc,
-  svd_trunc!
+using MatrixAlgebraKit
 
 for (f, f_full, f_compact) in (
   (:qr, :qr_full, :qr_compact),

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -128,7 +128,7 @@ for (factorize, orth_f) in ((:factorize, :(MatrixAlgebra.orth)), (:factorize!, :
       else
         throw(ArgumentError("`orth=$orth` not supported."))
       end
-      return f(A; kwargs...)
+      return f(A; side=orth, kwargs...)
     end
   end
 end

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -1,5 +1,24 @@
 module MatrixAlgebra
 
+export eigen,
+  eigen!,
+  eigvals,
+  eigvals!,
+  factorize,
+  factorize!,
+  lq,
+  lq!,
+  orth,
+  orth!,
+  polar,
+  polar!,
+  qr,
+  qr!,
+  svd,
+  svd!,
+  svdvals,
+  svdvals!
+
 using LinearAlgebra: LinearAlgebra
 using MatrixAlgebraKit
 
@@ -57,6 +76,14 @@ for (svd, svd_trunc, svd_full, svd_compact) in (
       else
         (full ? $svd_full : $svd_compact)(A; kwargs...)
       end
+    end
+  end
+end
+
+for (svdvals, svd_vals) in ((:svdvals, :svd_vals), (:svdvals!, :svd_vals!))
+  @eval begin
+    function $svdvals(A::AbstractMatrix; ishermitian=nothing, kwargs...)
+      return $svd_vals(A; kwargs...)
     end
   end
 end

--- a/src/TensorAlgebra.jl
+++ b/src/TensorAlgebra.jl
@@ -2,6 +2,8 @@ module TensorAlgebra
 
 export contract, contract!, eigen, eigvals, lq, left_null, qr, right_null, svd, svdvals
 
+include("MatrixAlgebra.jl")
+using .MatrixAlgebra: MatrixAlgebra
 include("blockedtuple.jl")
 include("blockedpermutation.jl")
 include("BaseExtensions/BaseExtensions.jl")

--- a/src/TensorAlgebra.jl
+++ b/src/TensorAlgebra.jl
@@ -3,7 +3,6 @@ module TensorAlgebra
 export contract, contract!, eigen, eigvals, lq, left_null, qr, right_null, svd, svdvals
 
 include("MatrixAlgebra.jl")
-using .MatrixAlgebra: MatrixAlgebra
 include("blockedtuple.jl")
 include("blockedpermutation.jl")
 include("BaseExtensions/BaseExtensions.jl")

--- a/src/TensorAlgebra.jl
+++ b/src/TensorAlgebra.jl
@@ -1,6 +1,22 @@
 module TensorAlgebra
 
-export contract, contract!, eigen, eigvals, lq, left_null, qr, right_null, svd, svdvals
+export contract,
+  contract!,
+  eigen,
+  eigvals,
+  factorize,
+  left_null,
+  left_orth,
+  left_polar,
+  lq,
+  qr,
+  right_null,
+  right_orth,
+  right_polar,
+  orth,
+  polar,
+  svd,
+  svdvals
 
 include("MatrixAlgebra.jl")
 include("blockedtuple.jl")

--- a/src/factorizations.jl
+++ b/src/factorizations.jl
@@ -252,7 +252,7 @@ function svdvals(A::AbstractArray, labels_A, labels_codomain, labels_domain)
 end
 function svdvals(A::AbstractArray, biperm::BlockedPermutation{2})
   A_mat = fusedims(A, biperm)
-  return MatrixAlgebraKit.svd_vals!(A_mat)
+  return MatrixAlgebra.svdvals!(A_mat)
 end
 
 """

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -7,12 +7,42 @@ using Test: @test, @testset
     :contract!,
     :eigen,
     :eigvals,
+    :factorize,
     :left_null,
+    :left_orth,
+    :left_polar,
     :lq,
+    :orth,
+    :polar,
     :qr,
     :right_null,
+    :right_orth,
+    :right_polar,
     :svd,
     :svdvals,
   ]
   @test issetequal(names(TensorAlgebra), exports)
+
+  exports = [
+    :MatrixAlgebra,
+    :eigen,
+    :eigen!,
+    :eigvals,
+    :eigvals!,
+    :factorize,
+    :factorize!,
+    :lq,
+    :lq!,
+    :orth,
+    :orth!,
+    :polar,
+    :polar!,
+    :qr,
+    :qr!,
+    :svd,
+    :svd!,
+    :svdvals,
+    :svdvals!,
+  ]
+  @test issetequal(names(TensorAlgebra.MatrixAlgebra), exports)
 end

--- a/test/test_factorizations.jl
+++ b/test/test_factorizations.jl
@@ -10,6 +10,8 @@ using TensorAlgebra:
   left_orth,
   left_polar,
   lq,
+  orth,
+  polar,
   qr,
   right_null,
   right_orth,
@@ -216,11 +218,16 @@ end
   labels_P = (:d, :c)
 
   Acopy = deepcopy(A)
-  W, P = left_polar(A, labels_A, labels_W, labels_P)
-  @test A == Acopy # should not have altered initial array
-  A′ = contract(labels_A, W, (labels_W..., :w), P, (:w, labels_P...))
-  @test A ≈ A′
-  @test size(W, 3) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  for (W, P) in (
+    left_polar(A, labels_A, labels_W, labels_P),
+    polar(A, labels_A, labels_W, labels_P; side=:left),
+    polar(A, labels_A, labels_W, labels_P),
+  )
+    @test A == Acopy # should not have altered initial array
+    A′ = contract(labels_A, W, (labels_W..., :w), P, (:w, labels_P...))
+    @test A ≈ A′
+    @test size(W, 3) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  end
 end
 
 @testset "Right polar ($T)" for T in elts
@@ -230,11 +237,15 @@ end
   labels_W = (:d, :c)
 
   Acopy = deepcopy(A)
-  P, W = right_polar(A, labels_A, labels_P, labels_W)
-  @test A == Acopy # should not have altered initial array
-  A′ = contract(labels_A, P, (labels_P..., :w), W, (:w, labels_W...))
-  @test A ≈ A′
-  @test size(W, 1) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  for (P, W) in (
+    right_polar(A, labels_A, labels_P, labels_W),
+    polar(A, labels_A, labels_P, labels_W; side=:right),
+  )
+    @test A == Acopy # should not have altered initial array
+    A′ = contract(labels_A, P, (labels_P..., :w), W, (:w, labels_W...))
+    @test A ≈ A′
+    @test size(W, 1) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  end
 end
 
 @testset "Left orth ($T)" for T in elts
@@ -244,11 +255,16 @@ end
   labels_P = (:d, :c)
 
   Acopy = deepcopy(A)
-  W, P = left_orth(A, labels_A, labels_W, labels_P)
-  @test A == Acopy # should not have altered initial array
-  A′ = contract(labels_A, W, (labels_W..., :w), P, (:w, labels_P...))
-  @test A ≈ A′
-  @test size(W, 3) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  for (W, P) in (
+    left_orth(A, labels_A, labels_W, labels_P),
+    orth(A, labels_A, labels_W, labels_P; side=:left),
+    orth(A, labels_A, labels_W, labels_P),
+  )
+    @test A == Acopy # should not have altered initial array
+    A′ = contract(labels_A, W, (labels_W..., :w), P, (:w, labels_P...))
+    @test A ≈ A′
+    @test size(W, 3) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  end
 end
 
 @testset "Right orth ($T)" for T in elts
@@ -258,11 +274,15 @@ end
   labels_W = (:d, :c)
 
   Acopy = deepcopy(A)
-  P, W = right_orth(A, labels_A, labels_P, labels_W)
-  @test A == Acopy # should not have altered initial array
-  A′ = contract(labels_A, P, (labels_P..., :w), W, (:w, labels_W...))
-  @test A ≈ A′
-  @test size(W, 1) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  for (P, W) in (
+    right_orth(A, labels_A, labels_P, labels_W),
+    orth(A, labels_A, labels_P, labels_W; side=:right),
+  )
+    @test A == Acopy # should not have altered initial array
+    A′ = contract(labels_A, P, (labels_P..., :w), W, (:w, labels_W...))
+    @test A ≈ A′
+    @test size(W, 1) == min(size(A, 1) * size(A, 2), size(A, 3) * size(A, 4))
+  end
 end
 
 @testset "factorize ($T)" for T in elts

--- a/test/test_matrixalgebra.jl
+++ b/test/test_matrixalgebra.jl
@@ -1,10 +1,10 @@
-using LinearAlgebra: I, diag
+using LinearAlgebra: I, diag, isposdef
 using TensorAlgebra.MatrixAlgebra: MatrixAlgebra
 using Test: @test, @testset
 
 elts = (Float32, Float64, ComplexF32, ComplexF64)
 
-@testset "elt=$elt" for elt in elts
+@testset "TensorAlgebra.MatrixAlgebra (elt=$elt)" for elt in elts
   A = randn(elt, 3, 2)
   for positive in (false, true)
     for (Q, R) in (MatrixAlgebra.qr(A; positive), MatrixAlgebra.qr(A; full=false, positive))

--- a/test/test_matrixalgebra.jl
+++ b/test/test_matrixalgebra.jl
@@ -1,0 +1,148 @@
+using LinearAlgebra: I, diag
+using TensorAlgebra.MatrixAlgebra: MatrixAlgebra
+using Test: @test, @testset
+
+elts = (Float32, Float64, ComplexF32, ComplexF64)
+
+@testset "elt=$elt" for elt in elts
+  A = randn(elt, 3, 2)
+  for positive in (false, true)
+    for (Q, R) in (MatrixAlgebra.qr(A; positive), MatrixAlgebra.qr(A; full=false, positive))
+      @test A ≈ Q * R
+      @test size(Q) == size(A)
+      @test size(R) == (size(A, 2), size(A, 2))
+      @test Q' * Q ≈ I
+      @test Q * Q' ≉ I
+      if positive
+        @test all(≥(0), real(diag(R)))
+        @test all(≈(0), imag(diag(R)))
+      end
+    end
+  end
+
+  A = randn(elt, 3, 2)
+  for positive in (false, true)
+    Q, R = MatrixAlgebra.qr(A; full=true, positive)
+    @test A ≈ Q * R
+    @test size(Q) == (size(A, 1), size(A, 1))
+    @test size(R) == size(A)
+    @test Q' * Q ≈ I
+    @test Q * Q' ≈ I
+    if positive
+      @test all(≥(0), real(diag(R)))
+      @test all(≈(0), imag(diag(R)))
+    end
+  end
+
+  A = randn(elt, 2, 3)
+  for positive in (false, true)
+    for (L, Q) in (MatrixAlgebra.lq(A; positive), MatrixAlgebra.lq(A; full=false, positive))
+      @test A ≈ L * Q
+      @test size(L) == (size(A, 1), size(A, 1))
+      @test size(Q) == size(A)
+      @test Q * Q' ≈ I
+      @test Q' * Q ≉ I
+      if positive
+        @test all(≥(0), real(diag(L)))
+        @test all(≈(0), imag(diag(L)))
+      end
+    end
+  end
+
+  A = randn(elt, 3, 2)
+  for positive in (false, true)
+    L, Q = MatrixAlgebra.lq(A; full=true, positive)
+    @test A ≈ L * Q
+    @test size(L) == size(A)
+    @test size(Q) == (size(A, 2), size(A, 2))
+    @test Q * Q' ≈ I
+    @test Q' * Q ≈ I
+    if positive
+      @test all(≥(0), real(diag(L)))
+      @test all(≈(0), imag(diag(L)))
+    end
+  end
+
+  A = randn(elt, 3, 2)
+  for (W, C) in (MatrixAlgebra.orth(A), MatrixAlgebra.orth(A; side=:left))
+    @test A ≈ W * C
+    @test size(W) == size(A)
+    @test size(C) == (size(A, 2), size(A, 2))
+    @test W' * W ≈ I
+    @test W * W' ≉ I
+  end
+
+  A = randn(elt, 2, 3)
+  C, W = MatrixAlgebra.orth(A; side=:right)
+  @test A ≈ C * W
+  @test size(C) == (size(A, 1), size(A, 1))
+  @test size(W) == size(A)
+  @test W * W' ≈ I
+  @test W' * W ≉ I
+
+  A = randn(elt, 3, 2)
+  for (W, P) in (MatrixAlgebra.polar(A), MatrixAlgebra.polar(A; side=:left))
+    @test A ≈ W * P
+    @test size(W) == size(A)
+    @test size(P) == (size(A, 2), size(A, 2))
+    @test W' * W ≈ I
+    @test W * W' ≉ I
+    @test isposdef(P)
+  end
+
+  A = randn(elt, 2, 3)
+  P, W = MatrixAlgebra.polar(A; side=:right)
+  @test A ≈ P * W
+  @test size(P) == (size(A, 1), size(A, 1))
+  @test size(W) == size(A)
+  @test W * W' ≈ I
+  @test W' * W ≉ I
+  @test isposdef(P)
+
+  A = randn(elt, 3, 2)
+  for (W, C) in (MatrixAlgebra.factorize(A), MatrixAlgebra.factorize(A; orth=:left))
+    @test A ≈ W * C
+    @test size(W) == size(A)
+    @test size(C) == (size(A, 2), size(A, 2))
+    @test W' * W ≈ I
+    @test W * W' ≉ I
+  end
+
+  A = randn(elt, 2, 3)
+  C, W = MatrixAlgebra.factorize(A; orth=:right)
+  @test A ≈ C * W
+  @test size(C) == (size(A, 1), size(A, 1))
+  @test size(W) == size(A)
+  @test W * W' ≈ I
+  @test W' * W ≉ I
+
+  A = randn(elt, 3, 3)
+  D, V = MatrixAlgebra.eigen(A)
+  @test A * V ≈ V * D
+  @test MatrixAlgebra.eigvals(A) ≈ diag(D)
+
+  A = randn(elt, 3, 2)
+  for (U, S, V) in (MatrixAlgebra.svd(A), MatrixAlgebra.svd(A; full=false))
+    @test A ≈ U * S * V
+    @test size(U) == size(A)
+    @test size(S) == (size(A, 2), size(A, 2))
+    @test size(V) == (size(A, 2), size(A, 2))
+    @test U' * U ≈ I
+    @test U * U' ≉ I
+    @test V * V' ≈ I
+    @test V' * V ≈ I
+    @test MatrixAlgebra.svdvals(A) ≈ diag(S)
+  end
+
+  A = randn(elt, 3, 2)
+  U, S, V = MatrixAlgebra.svd(A; full=true)
+  @test A ≈ U * S * V
+  @test size(U) == (size(A, 1), size(A, 1))
+  @test size(S) == size(A)
+  @test size(V) == (size(A, 2), size(A, 2))
+  @test U' * U ≈ I
+  @test U * U' ≈ I
+  @test V * V' ≈ I
+  @test V' * V ≈ I
+  @test MatrixAlgebra.svdvals(A) ≈ diag(S)
+end


### PR DESCRIPTION
This moves logic for selecting the proper MatrixAlgebraKit.jl matrix factorization from the tensor level to the matrix level by introducing a submodule `TensorAlgebra.MatrixAlgebra`. This enables making some of the tensor factorization definitions more compact by generating them in an `@eval` loop. It also introduces new shorthand factorizations `polar` and `orth`, where left or right can be selected with a keyword argument.