### PR TITLE
`FusionStyle` on type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -10,19 +10,11 @@ abstract type FusionStyle end
 
 struct ReshapeFusion <: FusionStyle end
 
-FusionStyle(a::AbstractArray) = FusionStyle(a, axes(a))
-function FusionStyle(a::AbstractArray, t::Tuple{Vararg{AbstractUnitRange}})
-  return FusionStyle(a, combine_fusion_styles(FusionStyle.(t)...))
-end
+FusionStyle(x) = FusionStyle(typeof(x))
+FusionStle(::Type) = error("Not implemented")
 
 # Defaults to ReshapeFusion, a simple reshape
-FusionStyle(::AbstractUnitRange) = ReshapeFusion()
-FusionStyle(::AbstractArray, ::ReshapeFusion) = ReshapeFusion()
-
-combine_fusion_styles() = ReshapeFusion()
-combine_fusion_styles(::Style, ::Style) where {Style<:FusionStyle} = Style()
-combine_fusion_styles(::FusionStyle, ::FusionStyle) = ReshapeFusion()
-combine_fusion_styles(styles::FusionStyle...) = foldl(combine_fusion_styles, styles)
+FusionStyle(::Type{<:AbstractArray}) = ReshapeFusion()
 
 # =======================================  misc  ========================================
 trivial_axis(::Tuple{}) = Base.OneTo(1)

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -11,7 +11,7 @@ abstract type FusionStyle end
 struct ReshapeFusion <: FusionStyle end
 
 FusionStyle(x) = FusionStyle(typeof(x))
-FusionStle(::Type) = error("Not implemented")
+FusionStyle(T::Type) = throw(MethodError(FusionStyle, (T,)))
 
 # Defaults to ReshapeFusion, a simple reshape
 FusionStyle(::Type{<:AbstractArray}) = ReshapeFusion()


### PR DESCRIPTION
This PR changes `FusionStyle` to act on type. It removes the explicit dependency on axes as well as `combine_fusion_styles`.