### PR TITLE
use `BlockedTuple` for default `label_dest`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/contract/allocate_output.jl
+++ b/src/contract/allocate_output.jl
@@ -1,5 +1,18 @@
 using Base.PermutedDimsArrays: genperm
 
+function checkndims(a1, labels1, a2, labels2)
+  ndims(a1) == length(labels1) ||
+    throw(ArgumentError("Invalid permutation for left tensor"))
+  return ndims(a2) == length(labels2) ||
+         throw(ArgumentError("Invalid permutation for right tensor"))
+end
+
+function checkndims(a_dest, labels_dest, a1, labels1, a2, labels2)
+  ndims(a_dest) == length(labels_dest) ||
+    throw(ArgumentError("Invalid permutation for destination tensor"))
+  return checkndims(a1, labels1, a2, labels2)
+end
+
 # TODO: Use `ArrayLayouts`-like `MulAdd` object,
 # i.e. `ContractAdd`?
 function output_axes(
@@ -28,6 +41,9 @@ function allocate_output(
   biperm2::AbstractBlockPermutation,
   α::Number=one(Bool),
 )
+  checkndims(a1, biperm1, a2, biperm2)
+  blocklengths(biperm_dest) == (length(biperm1[Block(1)]), length(biperm2[Block(2)])) ||
+    throw(ArgumentError("Invalid permutation for destination tensor"))
   axes_dest = output_axes(contract, biperm_dest, a1, biperm1, a2, biperm2, α)
   return similar(a1, promote_type(eltype(a1), eltype(a2), typeof(α)), axes_dest)
 end

--- a/src/contract/allocate_output.jl
+++ b/src/contract/allocate_output.jl
@@ -1,16 +1,16 @@
 using Base.PermutedDimsArrays: genperm
 
-function checkndims(a1, labels1, a2, labels2)
+function check_input(::typeof(contract), a1, labels1, a2, labels2)
   ndims(a1) == length(labels1) ||
     throw(ArgumentError("Invalid permutation for left tensor"))
   return ndims(a2) == length(labels2) ||
          throw(ArgumentError("Invalid permutation for right tensor"))
 end
 
-function checkndims(a_dest, labels_dest, a1, labels1, a2, labels2)
+function check_input(::typeof(contract), a_dest, labels_dest, a1, labels1, a2, labels2)
   ndims(a_dest) == length(labels_dest) ||
     throw(ArgumentError("Invalid permutation for destination tensor"))
-  return checkndims(a1, labels1, a2, labels2)
+  return check_input(contract, a1, labels1, a2, labels2)
 end
 
 # TODO: Use `ArrayLayouts`-like `MulAdd` object,
@@ -41,7 +41,7 @@ function allocate_output(
   biperm2::AbstractBlockPermutation,
   α::Number=one(Bool),
 )
-  checkndims(a1, biperm1, a2, biperm2)
+  check_input(contract, a1, biperm1, a2, biperm2)
   blocklengths(biperm_dest) == (length(biperm1[Block(1)]), length(biperm2[Block(2)])) ||
     throw(ArgumentError("Invalid permutation for destination tensor"))
   axes_dest = output_axes(contract, biperm_dest, a1, biperm1, a2, biperm2, α)

--- a/src/contract/blockedperms.jl
+++ b/src/contract/blockedperms.jl
@@ -8,6 +8,11 @@ end
 
 # codomain <-- domain
 function blockedperms(::typeof(contract), dimnames_dest, dimnames1, dimnames2)
+  dimnames = collect(Iterators.flatten((dimnames_dest, dimnames1, dimnames2)))
+  for i in unique(dimnames)
+    count(==(i), dimnames) == 2 || throw(ArgumentError("Invalid contraction labels"))
+  end
+
   codomain = Tuple(setdiff(dimnames1, dimnames2))
   contracted = Tuple(intersect(dimnames1, dimnames2))
   domain = Tuple(setdiff(dimnames2, dimnames1))

--- a/src/contract/contract.jl
+++ b/src/contract/contract.jl
@@ -88,6 +88,7 @@ function contract(
   α::Number=one(Bool);
   kwargs...,
 )
+  checkndims(a1, labels1, a2, labels2)
   biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
   return contract(alg, biperm_dest, a1, biperm1, a2, biperm2, α; kwargs...)
 end
@@ -104,6 +105,7 @@ function contract!(
   β::Number;
   kwargs...,
 )
+  checkndims(a_dest, labels_dest, a1, labels1, a2, labels2)
   biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
   return contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, β; kwargs...)
 end
@@ -118,6 +120,7 @@ function contract(
   α::Number;
   kwargs...,
 )
+  checkndims(a1, biperm1, a2, biperm2)
   a_dest = allocate_output(contract, biperm_dest, a1, biperm1, a2, biperm2, α)
   contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, zero(Bool); kwargs...)
   return a_dest

--- a/src/contract/contract.jl
+++ b/src/contract/contract.jl
@@ -88,7 +88,7 @@ function contract(
   α::Number=one(Bool);
   kwargs...,
 )
-  checkndims(a1, labels1, a2, labels2)
+  check_input(contract, a1, labels1, a2, labels2)
   biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
   return contract(alg, biperm_dest, a1, biperm1, a2, biperm2, α; kwargs...)
 end
@@ -105,7 +105,7 @@ function contract!(
   β::Number;
   kwargs...,
 )
-  checkndims(a_dest, labels_dest, a1, labels1, a2, labels2)
+  check_input(contract, a_dest, labels_dest, a1, labels1, a2, labels2)
   biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
   return contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, β; kwargs...)
 end
@@ -120,7 +120,7 @@ function contract(
   α::Number;
   kwargs...,
 )
-  checkndims(a1, biperm1, a2, biperm2)
+  check_input(contract, a1, biperm1, a2, biperm2)
   a_dest = allocate_output(contract, biperm_dest, a1, biperm1, a2, biperm2, α)
   contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, zero(Bool); kwargs...)
   return a_dest

--- a/src/contract/contract_matricize/contract.jl
+++ b/src/contract/contract_matricize/contract.jl
@@ -11,7 +11,7 @@ function contract!(
   α::Number,
   β::Number,
 )
-  checkndims(a_dest, biperm_dest, a1, biperm1, a2, biperm2)
+  check_input(contract, a_dest, biperm_dest, a1, biperm1, a2, biperm2)
   a_dest_mat = matricize(a_dest, biperm_dest)
   a1_mat = matricize(a1, biperm1)
   a2_mat = matricize(a2, biperm2)

--- a/src/contract/contract_matricize/contract.jl
+++ b/src/contract/contract_matricize/contract.jl
@@ -11,6 +11,7 @@ function contract!(
   α::Number,
   β::Number,
 )
+  checkndims(a_dest, biperm_dest, a1, biperm1, a2, biperm2)
   a_dest_mat = matricize(a_dest, biperm_dest)
   a1_mat = matricize(a1, biperm1)
   a2_mat = matricize(a2, biperm2)

--- a/src/contract/output_labels.jl
+++ b/src/contract/output_labels.jl
@@ -10,10 +10,11 @@ function output_labels(
   return output_labels(f, alg, labels1, labels2)
 end
 
-function output_labels(f::typeof(contract), alg::Algorithm, labels1, labels2)
+function output_labels(f::typeof(contract), ::Algorithm, labels1, labels2)
   return output_labels(f, labels1, labels2)
 end
 
 function output_labels(::typeof(contract), labels1, labels2)
-  return Tuple(symdiff(labels1, labels2))
+  diff = symdiff(labels1, labels2)
+  return tuplemortar((Tuple(intersect(diff, labels1)), Tuple(intersect(diff, labels2))))
 end

--- a/src/contract/output_labels.jl
+++ b/src/contract/output_labels.jl
@@ -15,6 +15,7 @@ function output_labels(f::typeof(contract), ::Algorithm, labels1, labels2)
 end
 
 function output_labels(::typeof(contract), labels1, labels2)
-  diff = symdiff(labels1, labels2)
-  return tuplemortar((Tuple(intersect(diff, labels1)), Tuple(intersect(diff, labels2))))
+  diff1 = Tuple(setdiff(labels1, labels2))
+  diff2 = Tuple(setdiff(labels2, labels1))
+  return tuplemortar((diff1, diff2))
 end

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -46,6 +46,7 @@ end
 # maybe: copy=false kwarg
 
 function matricize(a::AbstractArray, biperm::AbstractBlockPermutation{2})
+  ndims(a) == length(biperm) || throw(ArgumentError("Invalid bipermutation"))
   return matricize(FusionStyle(a), a, biperm)
 end
 
@@ -78,6 +79,7 @@ function unmatricize(
   axes::Tuple{Vararg{AbstractUnitRange}},
   biperm::AbstractBlockPermutation{2},
 )
+  length(axes) == length(biperm) || throw(ArgumentError("axes do not match permutation"))
   return unmatricize(FusionStyle(m), m, axes, biperm)
 end
 
@@ -122,6 +124,8 @@ end
 function unmatricize!(
   a::AbstractArray, m::AbstractMatrix, biperm::AbstractBlockPermutation{2}
 )
+  ndims(a) == length(biperm) ||
+    throw(ArgumentError("destination does not match permutation"))
   blocked_axes = axes(a)[biperm]
   a_perm = unmatricize(m, blocked_axes)
   return permuteblockeddims!(a, a_perm, invperm(biperm))

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -170,7 +170,8 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
       # Don't specify destination labels
       a_dest, labels_dest′ = contract(a1, labels1, a2, labels2)
-      @test labels_dest′ isa BlockedTuple{2}
+      @test labels_dest′ isa
+        BlockedTuple{2,(length(setdiff(d1s, d2s)), length(setdiff(d2s, d1s)))}
       a_dest_tensoroperations = TensorOperations.tensorcontract(
         Tuple(labels_dest′), a1, labels1, a2, labels2
       )


### PR DESCRIPTION
When `label_dest` is not provided, `contract` automatically determines it from `labels1` and `labels2` and returns it. It currently output it as a `Tuple`. This PR makes it return a `BlockedTuple{2}`.

This PR also add many sanity checks.