### PR TITLE
Add missing trunc arguments to eigen functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -44,12 +44,19 @@ for (eigen, eigh_full, eig_full, eigh_trunc, eig_trunc) in (
   @eval begin
     function $eigen(A::AbstractMatrix; trunc=nothing, ishermitian=nothing, kwargs...)
       ishermitian = @something ishermitian LinearAlgebra.ishermitian(A)
-      f = if !isnothing(trunc)
-        ishermitian ? $eigh_trunc : $eig_trunc
+      return if !isnothing(trunc)
+        if ishermitian
+          $eigh_trunc(A; trunc, kwargs...)
+        else
+          $eig_trunc(A; trunc, kwargs...)
+        end
       else
-        ishermitian ? $eigh_full : $eig_full
+        if ishermitian(trunc)
+          $eigh_full(A; kwargs...)
+        else
+          $eig_full(A; kwargs...)
+        end
       end
-      return f(A; kwargs...)
     end
   end
 end

--- a/src/MatrixAlgebra.jl
+++ b/src/MatrixAlgebra.jl
@@ -51,7 +51,7 @@ for (eigen, eigh_full, eig_full, eigh_trunc, eig_trunc) in (
           $eig_trunc(A; trunc, kwargs...)
         end
       else
-        if ishermitian(trunc)
+        if ishermitian
           $eigh_full(A; kwargs...)
         else
           $eig_full(A; kwargs...)


### PR DESCRIPTION
Noticed that the truncation was being ignored in `MatrixAlgebra` eigenvalue wrappers. 