### PR TITLE
remove `label_dest` in `contract`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.10"
+version = "0.3.11"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/contract/allocate_output.jl
+++ b/src/contract/allocate_output.jl
@@ -7,8 +7,8 @@ function check_input(::typeof(contract), a1, labels1, a2, labels2)
          throw(ArgumentError("Invalid permutation for right tensor"))
 end
 
-function check_input(::typeof(contract), a_dest, labels_dest, a1, labels1, a2, labels2)
-  ndims(a_dest) == length(labels_dest) ||
+function check_input(::typeof(contract), a_dest, labels_out, a1, labels1, a2, labels2)
+  ndims(a_dest) == length(labels_out) ||
     throw(ArgumentError("Invalid permutation for destination tensor"))
   return check_input(contract, a1, labels1, a2, labels2)
 end
@@ -17,7 +17,6 @@ end
 # i.e. `ContractAdd`?
 function output_axes(
   ::typeof(contract),
-  biperm_dest::AbstractBlockPermutation{2},
   a1::AbstractArray,
   biperm1::AbstractBlockPermutation{2},
   a2::AbstractArray,
@@ -26,15 +25,15 @@ function output_axes(
 )
   axes_codomain, axes_contracted = blocks(axes(a1)[biperm1])
   axes_contracted2, axes_domain = blocks(axes(a2)[biperm2])
+  biperm_out = blockedtrivialperm((length(biperm1[Block(1)]), length(biperm2[Block(2)])))
   @assert axes_contracted == axes_contracted2
-  return genperm((axes_codomain..., axes_domain...), invperm(Tuple(biperm_dest)))
+  return genperm((axes_codomain..., axes_domain...), Tuple(biperm_out))
 end
 
 # TODO: Use `ArrayLayouts`-like `MulAdd` object,
 # i.e. `ContractAdd`?
 function allocate_output(
   ::typeof(contract),
-  biperm_dest::AbstractBlockPermutation,
   a1::AbstractArray,
   biperm1::AbstractBlockPermutation,
   a2::AbstractArray,
@@ -42,8 +41,6 @@ function allocate_output(
   α::Number=one(Bool),
 )
   check_input(contract, a1, biperm1, a2, biperm2)
-  blocklengths(biperm_dest) == (length(biperm1[Block(1)]), length(biperm2[Block(2)])) ||
-    throw(ArgumentError("Invalid permutation for destination tensor"))
-  axes_dest = output_axes(contract, biperm_dest, a1, biperm1, a2, biperm2, α)
+  axes_dest = output_axes(contract, a1, biperm1, a2, biperm2, α)
   return similar(a1, promote_type(eltype(a1), eltype(a2), typeof(α)), axes_dest)
 end

--- a/src/contract/blockedperms.jl
+++ b/src/contract/blockedperms.jl
@@ -1,24 +1,19 @@
 using .BaseExtensions: BaseExtensions
 
-function blockedperms(
-  f::typeof(contract), alg::Algorithm, dimnames_dest, dimnames1, dimnames2
-)
-  return blockedperms(f, dimnames_dest, dimnames1, dimnames2)
+function blockedperms(f::typeof(contract), ::Algorithm, dimnames1, dimnames2)
+  return blockedperms(f, dimnames1, dimnames2)
 end
 
 # codomain <-- domain
-function blockedperms(::typeof(contract), dimnames_dest, dimnames1, dimnames2)
-  dimnames = collect(Iterators.flatten((dimnames_dest, dimnames1, dimnames2)))
+function blockedperms(::typeof(contract), dimnames1, dimnames2)
+  dimnames = collect(Iterators.flatten((dimnames1, dimnames2)))
   for i in unique(dimnames)
-    count(==(i), dimnames) == 2 || throw(ArgumentError("Invalid contraction labels"))
+    count(==(i), dimnames) in (1, 2) || throw(ArgumentError("Invalid contraction labels"))
   end
 
   codomain = Tuple(setdiff(dimnames1, dimnames2))
   contracted = Tuple(intersect(dimnames1, dimnames2))
   domain = Tuple(setdiff(dimnames2, dimnames1))
-
-  perm_codomain_dest = BaseExtensions.indexin(codomain, dimnames_dest)
-  perm_domain_dest = BaseExtensions.indexin(domain, dimnames_dest)
 
   perm_codomain1 = BaseExtensions.indexin(codomain, dimnames1)
   perm_domain1 = BaseExtensions.indexin(contracted, dimnames1)
@@ -26,11 +21,9 @@ function blockedperms(::typeof(contract), dimnames_dest, dimnames1, dimnames2)
   perm_codomain2 = BaseExtensions.indexin(contracted, dimnames2)
   perm_domain2 = BaseExtensions.indexin(domain, dimnames2)
 
-  permblocks_dest = (perm_codomain_dest, perm_domain_dest)
-  biperm_dest = blockedpermvcat(permblocks_dest...)
   permblocks1 = (perm_codomain1, perm_domain1)
   biperm1 = blockedpermvcat(permblocks1...)
   permblocks2 = (perm_codomain2, perm_domain2)
   biperm2 = blockedpermvcat(permblocks2...)
-  return biperm_dest, biperm1, biperm2
+  return biperm1, biperm2
 end

--- a/src/contract/contract.jl
+++ b/src/contract/contract.jl
@@ -13,7 +13,6 @@ default_contract_alg() = Matricize()
 function contract!(
   alg::Algorithm,
   a_dest::AbstractArray,
-  biperm_dest::AbstractBlockPermutation,
   a1::AbstractArray,
   biperm1::AbstractBlockPermutation,
   a2::AbstractArray,
@@ -36,35 +35,8 @@ function contract(
   return contract(Algorithm(alg), a1, labels1, a2, labels2, α; kwargs...)
 end
 
-function contract(
-  alg::Algorithm,
-  a1::AbstractArray,
-  labels1,
-  a2::AbstractArray,
-  labels2,
-  α::Number=one(Bool);
-  kwargs...,
-)
-  labels_dest = output_labels(contract, alg, a1, labels1, a2, labels2, α; kwargs...)
-  return contract(alg, labels_dest, a1, labels1, a2, labels2, α; kwargs...), labels_dest
-end
-
-function contract(
-  labels_dest,
-  a1::AbstractArray,
-  labels1,
-  a2::AbstractArray,
-  labels2,
-  α::Number=one(Bool);
-  alg=default_contract_alg(),
-  kwargs...,
-)
-  return contract(Algorithm(alg), labels_dest, a1, labels1, a2, labels2, α; kwargs...)
-end
-
 function contract!(
   a_dest::AbstractArray,
-  labels_dest,
   a1::AbstractArray,
   labels1,
   a2::AbstractArray,
@@ -74,13 +46,12 @@ function contract!(
   alg=default_contract_alg(),
   kwargs...,
 )
-  contract!(Algorithm(alg), a_dest, labels_dest, a1, labels1, a2, labels2, α, β; kwargs...)
+  contract!(Algorithm(alg), a_dest, a1, labels1, a2, labels2, α, β; kwargs...)
   return a_dest
 end
 
 function contract(
   alg::Algorithm,
-  labels_dest,
   a1::AbstractArray,
   labels1,
   a2::AbstractArray,
@@ -89,14 +60,14 @@ function contract(
   kwargs...,
 )
   check_input(contract, a1, labels1, a2, labels2)
-  biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
-  return contract(alg, biperm_dest, a1, biperm1, a2, biperm2, α; kwargs...)
+  biperm1, biperm2 = blockedperms(contract, labels1, labels2)
+  labels_dest = output_labels(contract, alg, a1, labels1, a2, labels2, α; kwargs...)
+  return contract(alg, a1, biperm1, a2, biperm2, α; kwargs...), labels_dest
 end
 
 function contract!(
   alg::Algorithm,
   a_dest::AbstractArray,
-  labels_dest,
   a1::AbstractArray,
   labels1,
   a2::AbstractArray,
@@ -105,14 +76,13 @@ function contract!(
   β::Number;
   kwargs...,
 )
-  check_input(contract, a_dest, labels_dest, a1, labels1, a2, labels2)
-  biperm_dest, biperm1, biperm2 = blockedperms(contract, labels_dest, labels1, labels2)
-  return contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, β; kwargs...)
+  check_input(contract, a1, labels1, a2, labels2)
+  biperm1, biperm2 = blockedperms(contract, labels1, labels2)
+  return contract!(alg, a_dest, a1, biperm1, a2, biperm2, α, β; kwargs...)
 end
 
 function contract(
   alg::Algorithm,
-  biperm_dest::AbstractBlockPermutation,
   a1::AbstractArray,
   biperm1::AbstractBlockPermutation,
   a2::AbstractArray,
@@ -121,7 +91,7 @@ function contract(
   kwargs...,
 )
   check_input(contract, a1, biperm1, a2, biperm2)
-  a_dest = allocate_output(contract, biperm_dest, a1, biperm1, a2, biperm2, α)
-  contract!(alg, a_dest, biperm_dest, a1, biperm1, a2, biperm2, α, zero(Bool); kwargs...)
+  a_dest = allocate_output(contract, a1, biperm1, a2, biperm2, α)
+  contract!(alg, a_dest, a1, biperm1, a2, biperm2, α, zero(Bool); kwargs...)
   return a_dest
 end

--- a/src/contract/contract_matricize/contract.jl
+++ b/src/contract/contract_matricize/contract.jl
@@ -3,7 +3,6 @@ using LinearAlgebra: mul!
 function contract!(
   ::Matricize,
   a_dest::AbstractArray,
-  biperm_dest::AbstractBlockPermutation{2},
   a1::AbstractArray,
   biperm1::AbstractBlockPermutation{2},
   a2::AbstractArray,
@@ -11,11 +10,12 @@ function contract!(
   α::Number,
   β::Number,
 )
-  check_input(contract, a_dest, biperm_dest, a1, biperm1, a2, biperm2)
-  a_dest_mat = matricize(a_dest, biperm_dest)
+  biperm_out = blockedtrivialperm((length(biperm1[Block(1)]), length(biperm2[Block(2)])))
+  check_input(contract, a_dest, biperm_out, a1, biperm1, a2, biperm2)
+  a_dest_mat = matricize(a_dest, biperm_out)
   a1_mat = matricize(a1, biperm1)
   a2_mat = matricize(a2, biperm2)
   mul!(a_dest_mat, a1_mat, a2_mat, α, β)
-  unmatricize!(a_dest, a_dest_mat, biperm_dest)
+  unmatricize!(a_dest, a_dest_mat, biperm_out)
   return a_dest
 end


### PR DESCRIPTION
As we discussed last week, there is a difficulty in `contract` to deal with both a given destination and a permutation for this destination. We settled on removing the `label_dest` argument such that the output is always returned without additional permutation. This PR removes `label_dest` everywhere in `contract`.

Locally my tests fail in `test_matrixalgebra.jl` for `Truncation` on `ComplexFloat32`. I did not change that part so I do not understand what is happening.
EDIT: CI is fine, so it must be my local config.