### PR TITLE
change `length_domain` default convention to all axes in codomain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.3.14"
+version = "0.3.15"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/contract/blockedperms.jl
+++ b/src/contract/blockedperms.jl
@@ -10,11 +10,11 @@ function biperm(perm, ::Val{BlockLength1}) where {BlockLength1}
   return blockedperm(Tuple(perm), (BlockLength1, length(perm) - BlockLength1))
 end
 
-length_codomain(t::AbstractBlockTuple{2}) = first(blocklengths(t))
-# Assume all dimensions are in the domain by default
-length_codomain(t) = 0
+length_domain(t::AbstractBlockTuple{2}) = last(blocklengths(t))
+# Assume all dimensions are in the codomain by default
+length_domain(t) = 0
 
-length_domain(t) = length(t) - length_codomain(t)
+length_codomain(t) = length(t) - length_domain(t)
 
 function blockedperms(
   f::typeof(contract), alg::Algorithm, dimnames_dest, dimnames1, dimnames2

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -26,9 +26,9 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
   @testset "misc" begin
     t = (1, 2, 3)
     bt = tuplemortar(((1, 2), (3,)))
-    @test length_codomain(t) == 0
+    @test length_codomain(t) == 3
     @test length_codomain(bt) == 2
-    @test length_domain(t) == 3
+    @test length_domain(t) == 0
     @test length_domain(bt) == 1
   end
 


### PR DESCRIPTION
This PR changes the convention of `length_domain` and `length_codomain` to return all axes in the codomain by default. This convention matches `TensorOperations.jl`.