### PR TITLE
CompatHelper: bump compat for StridedViews to 0.5, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -35,7 +35,7 @@ GPUArraysCore = "0.2"
 LinearAlgebra = "1.10"
 MatrixAlgebraKit = "0.2, 0.3, 0.4, 0.5, 0.6"
 Mooncake = "0.4.202, 0.5"
-StridedViews = "0.4.1"
+StridedViews = "0.4.1, 0.5"
 TensorOperations = "5"
 TupleTools = "1.6"
 TypeParameterAccessors = "0.2.1, 0.3, 0.4"


### PR DESCRIPTION
This pull request changes the compat entry for the `StridedViews` package from `0.4.1` to `0.4.1, 0.5`.
This keeps the compat entries for earlier versions.

CI was previously red because of the transitive `StridedViews` chain — that's now resolved after TypeParameterAccessors.jl#123 and FunctionImplementations.jl#53 merged and registered new versions. Re-ran CI against those releases; tests + Check Compat Bounds now green.