### PR TITLE
Remove redundant contractopadd!_matricize helper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/contract/contract_matricize.jl
+++ b/src/contract/contract_matricize.jl
@@ -7,33 +7,17 @@ function contractopadd!(
         op2, a2::AbstractArray, biperm2_codomain, biperm2_domain,
         α::Number, β::Number
     )
-    return contractopadd!_matricize(
-        algorithm,
-        a_dest, biperm_dest_codomain, biperm_dest_domain,
-        op1, a1, biperm1_codomain, biperm1_domain,
-        op2, a2, biperm2_codomain, biperm2_domain,
-        α, β
-    )
-end
-
-function contractopadd!_matricize(
-        algorithm::Matricize,
-        a_dest::AbstractArray, perm_dest_codomain, perm_dest_domain,
-        op1, a1::AbstractArray, perm1_codomain, perm1_domain,
-        op2, a2::AbstractArray, perm2_codomain, perm2_domain,
-        α::Number, β::Number
-    )
-    perm_dest = (perm_dest_codomain..., perm_dest_domain...)
+    biperm_dest = (biperm_dest_codomain..., biperm_dest_domain...)
     invperm_codomain, invperm_domain =
-        blocks(biperm(invperm(perm_dest), length(perm1_codomain)))
+        blocks(biperm(invperm(biperm_dest), length(biperm1_codomain)))
     check_input(
         contract!,
         a_dest, invperm_codomain, invperm_domain,
-        a1, perm1_codomain, perm1_domain,
-        a2, perm2_codomain, perm2_domain
+        a1, biperm1_codomain, biperm1_domain,
+        a2, biperm2_codomain, biperm2_domain
     )
-    a1_mat = matricizeop(algorithm.fusion_style, op1, a1, perm1_codomain, perm1_domain)
-    a2_mat = matricizeop(algorithm.fusion_style, op2, a2, perm2_codomain, perm2_domain)
+    a1_mat = matricizeop(algorithm.fusion_style, op1, a1, biperm1_codomain, biperm1_domain)
+    a2_mat = matricizeop(algorithm.fusion_style, op2, a2, biperm2_codomain, biperm2_domain)
     a_dest_mat = a1_mat * a2_mat
     unmatricizeadd!(
         algorithm.fusion_style, a_dest, a_dest_mat, invperm_codomain, invperm_domain, α, β

--- a/src/contract/contract_matricize.jl
+++ b/src/contract/contract_matricize.jl
@@ -1,5 +1,3 @@
-using LinearAlgebra: mul!
-
 function contractopadd!(
         algorithm::Matricize,
         a_dest::AbstractArray, biperm_dest_codomain, biperm_dest_domain,


### PR DESCRIPTION
## Summary

- The `contractopadd!(::Matricize, ...)` method only forwarded its arguments to a `contractopadd!_matricize` helper that did the actual matricize-based contraction. The extra layer of indirection added no value and was a source of confusion.
- Inline the helper body into the `Matricize` dispatch method and delete `contractopadd!_matricize`. Behavior is unchanged; the helper was internal (not exported/public) and was only ever reached through this one method.
- Drop the now-unused `using LinearAlgebra: mul!` import from the same file. The only remaining `mul!` use in the package is qualified as `LA.mul!` elsewhere.