### PR TITLE
Unwrap PermutedDimsArray sources in bipermutedimsopadd!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/permutedimsadd.jl
+++ b/src/permutedimsadd.jl
@@ -1,6 +1,13 @@
-using FunctionImplementations: permuteddims
 using Strided: Strided
 using StridedViews: StridedViews as SV
+
+"""
+    permuteddims(a, perm)
+
+Lazily permute the dimensions of `a` by `perm`. Defaults to `PermutedDimsArray`;
+overload for array types with a more efficient lazy permuted representation.
+"""
+permuteddims(a::AbstractArray, perm) = PermutedDimsArray(a, perm)
 
 # Specify if an array is on CPU. This is helpful for backends that don't support
 # operations on GPU, such as Strided.jl.
@@ -82,6 +89,21 @@ function bipermutedimsopadd!(
         end
     end
     return dest
+end
+
+_permuteddims_perm(::PermutedDimsArray{<:Any, <:Any, perm}) where {perm} = perm
+
+function bipermutedimsopadd!(
+        dest::AbstractArray, op, src::PermutedDimsArray,
+        perm_codomain, perm_domain,
+        α::Number, β::Number
+    )
+    w = _permuteddims_perm(src)
+    return bipermutedimsopadd!(
+        dest, op, parent(src),
+        map(j -> w[j], perm_codomain), map(j -> w[j], perm_domain),
+        α, β
+    )
 end
 
 # ---------------------------------------------------------------------------- #

--- a/src/permutedimsadd.jl
+++ b/src/permutedimsadd.jl
@@ -1,13 +1,6 @@
+using FunctionImplementations: permuteddims
 using Strided: Strided
 using StridedViews: StridedViews as SV
-
-"""
-    permuteddims(a, perm)
-
-Lazily permute the dimensions of `a` by `perm`. Defaults to `PermutedDimsArray`;
-overload for array types with a more efficient lazy permuted representation.
-"""
-permuteddims(a::AbstractArray, perm) = PermutedDimsArray(a, perm)
 
 # Specify if an array is on CPU. This is helpful for backends that don't support
 # operations on GPU, such as Strided.jl.

--- a/test/test_permutedimsadd.jl
+++ b/test/test_permutedimsadd.jl
@@ -47,6 +47,26 @@ using Test: @test, @testset
             @test b′ ≈ β * b + α * permutedims(a, perm)
         end
     end
+    @testset "bipermutedimsopadd! unwraps PermutedDimsArray src (arraytype=$arrayt)" for arrayt in
+        (
+            Array,
+            JLArray,
+        )
+        dev = adapt(arrayt)
+        parent = dev(randn(2, 3, 4, 5))
+        w = (3, 1, 4, 2)
+        src = PermutedDimsArray(parent, w)
+        for (pc, pd) in (((1, 2, 3, 4), ()), ((2, 4), (1, 3)), ((3, 1), (2, 4)))
+            perm = (pc..., pd...)
+            ref = permutedims(permutedims(parent, w), perm)
+            for β in (0, 3)
+                dest = dev(randn(size(ref)...))
+                dest′ = copy(dest)
+                bipermutedimsopadd!(dest′, identity, src, pc, pd, 2, β)
+                @test dest′ ≈ β * dest + 2 * ref
+            end
+        end
+    end
     @testset "bipermutedimsopadd! 0-dim with β=0 must not read dest (eltype=$T)" for T in
         (
             Float64,


### PR DESCRIPTION
## Summary

Adds a `bipermutedimsopadd!` method for `PermutedDimsArray` sources that rewrites each entry of the bipartitioned permutation through the wrapper's own permutation and recurses on `parent(src)`. The underlying array then dispatches its own `bipermutedimsopadd!`, so a graded or block-sparse backend reached through a `PermutedDimsArray` wrapper hits its block-wise overload rather than the generic body falling through on the wrapper and re-entering broadcasting. This is what lets a permuted source produced by `NamedDimsArrays` broadcast alignment lower to the backend primitive.