### PR TITLE
Return contraction output labels as a Vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.9.6"
+version = "0.9.7"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/blockedtuple.jl
+++ b/src/blockedtuple.jl
@@ -262,6 +262,9 @@ end
 # Base interface
 Base.Tuple(bt::BlockedTuple) = bt.flat
 
+# Forward the flat tuple's element type; otherwise `eltype` falls back to `Any`.
+Base.eltype(::Type{<:BlockedTuple{<:Any, <:Any, Flat}}) where {Flat} = eltype(Flat)
+
 # BlockArrays interface
 function blocklengths(
         ::Type{<:BlockedTuple{<:Any, BlockLengths}}

--- a/src/contract/blockedperms.jl
+++ b/src/contract/blockedperms.jl
@@ -29,7 +29,7 @@ function blockedperms(::typeof(contract), dimnames_dest, dimnames1, dimnames2)
     perm_codomain_dest = BaseExtensions.indexin(codomain, dimnames_dest)
     perm_domain_dest = BaseExtensions.indexin(domain, dimnames_dest)
     invbiperm = (perm_codomain_dest..., perm_domain_dest...)
-    biperm_dest = biperm(invperm(invbiperm), length_codomain(dimnames_dest))
+    biperm_dest = biperm(invperm(invbiperm), length(codomain))
 
     perm_codomain1 = BaseExtensions.indexin(codomain, dimnames1)
     perm_domain1 = BaseExtensions.indexin(contracted, dimnames1)

--- a/src/contract/contract_labels.jl
+++ b/src/contract/contract_labels.jl
@@ -2,7 +2,7 @@ function contract_labels(a1::AbstractArray, labels1, a2::AbstractArray, labels2)
     return contract_labels(labels1, labels2)
 end
 function contract_labels(labels1, labels2)
-    diff1 = Tuple(setdiff(labels1, labels2))
-    diff2 = Tuple(setdiff(labels2, labels1))
-    return tuplemortar((diff1, diff2))
+    diff1 = setdiff(labels1, labels2)
+    diff2 = setdiff(labels2, labels1)
+    return vcat(diff1, diff2)
 end

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -217,8 +217,7 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
             # Don't specify destination labels
             a_dest, labels_dest′ = contract(a1, labels1, a2, labels2)
-            @test labels_dest′ isa
-                BlockedTuple{2, (length(setdiff(d1s, d2s)), length(setdiff(d2s, d1s)))}
+            @test issetequal(labels_dest′, symdiff(labels1, labels2))
             a_dest_tensoroperations, = contract(
                 a1, labels1, a2, labels2; alg = alg_tensoroperations
             )
@@ -270,7 +269,7 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         a2 = randn(rng, elt2, 4, 5)
 
         a_dest, labels = contract(a1, ("i", "j"), a2, ("k", "l"))
-        @test labels == tuplemortar((("i", "j"), ("k", "l")))
+        @test labels == ["i", "j", "k", "l"]
         @test eltype(a_dest) === elt_dest
         @test a_dest ≈ reshape(vec(a1) * transpose(vec(a2)), (size(a1)..., size(a2)...))
 
@@ -403,17 +402,17 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
         # Array-scalar contraction.
         a_dest, labels_dest = contract(a, labels_a, s, ())
-        @test labels_dest == tuplemortar((labels_a, ()))
+        @test labels_dest == collect(labels_a)
         @test a_dest ≈ a * s[]
 
         # Scalar-array contraction.
         a_dest, labels_dest = contract(s, (), a, labels_a)
-        @test labels_dest == tuplemortar(((), labels_a))
+        @test labels_dest == collect(labels_a)
         @test a_dest ≈ a * s[]
 
         # Scalar-scalar contraction.
         a_dest, labels_dest = contract(s, (), t, ())
-        @test labels_dest == tuplemortar(((), ()))
+        @test isempty(labels_dest)
         @test a_dest[] ≈ s[] * t[]
 
         # Specify output labels.

--- a/test/test_blockedtuple.jl
+++ b/test/test_blockedtuple.jl
@@ -14,6 +14,12 @@ using TestExtras: @constinferred
 
     @test (@constinferred Tuple(bt)) == flat
     @test (@constinferred tuplemortar(((true,), ('a', 2), ("b", 3.0)))) == bt
+
+    # `eltype` forwards the underlying flat tuple's element type rather than `Any`.
+    @test eltype(bt) === eltype(flat)
+    bt_int = tuplemortar(((1,), (2, 3)))
+    @test eltype(bt_int) === Int
+    @test eltype(typeof(bt_int)) === Int
     @test BlockedTuple(flat, divs) == bt
     @test (@constinferred BlockedTuple(bt)) == bt
     @test blocklength(bt) == 3


### PR DESCRIPTION
## Summary

Returns the output labels from `contract` as a `Vector` rather than a `BlockedTuple`, so the labels keep their element type even for a full contraction. The labels previously came back as a `BlockedTuple`, whose `eltype` falls back to `Any`, and a full contraction produced an empty `Tuple{}` whose element type is `Union{}`. A downstream consumer that builds a labeled array from these labels (such as `ITensor` in ITensorBase) then widened its dim-name type, so `ITensor{IndexName} * ITensor{IndexName}` came back as `ITensor{Any}`.

`contract_labels` now returns `vcat(setdiff(labels1, labels2), setdiff(labels2, labels1))`, an ordinary `Vector` that carries the label element type even when empty. `blockedperms(contract, ...)` no longer relies on the destination labels carrying block structure, so it takes the codomain length directly.

Also adds an `eltype` method for `BlockedTuple` that forwards the underlying flat tuple's element type instead of falling back to `Any`.

The destination-label container is an implementation detail, so a few tests that asserted the exact `BlockedTuple` type or value were updated to check the labels by value or set membership.
