### PR TITLE
Permute the contraction result directly into the destination in unmatricizeadd!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -339,8 +339,17 @@ function unmatricizeadd!(
         invperm_codomain::Tuple{Vararg{Int}}, invperm_domain::Tuple{Vararg{Int}},
         α::Number, β::Number
     )
-    a = unmatricize(style, m, axes(a_dest), invperm_codomain, invperm_domain)
-    return add!(a_dest, a, α, β)
+    invbiperm = BiTuple(invperm_codomain, invperm_domain)
+    ndims(a_dest) == length(invbiperm) ||
+        throw(ArgumentError("destination does not match permutation"))
+    # Reshape `m` to the destination's matricized axes (a view), then permute it
+    # straight into `a_dest` with accumulation in a single pass, rather than
+    # allocating a permuted copy and then adding it. Mirrors `unmatricize!`.
+    a_perm = unmatricize(style, m, bipartition(axes(a_dest), invbiperm)...)
+    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(axes(a_dest))))
+    return bipermutedimsopadd!(
+        a_dest, identity, a_perm, biperm_dest.t1, biperm_dest.t2, α, β
+    )
 end
 
 # Defaults to ReshapeFusion, a simple reshape


### PR DESCRIPTION
## Summary

`unmatricizeadd!` materialized a permuted copy of the matricized contraction result and then added it into the destination. It now permutes that result straight into the destination in a single accumulating pass (via `bipermutedimsopadd!`), mirroring `unmatricize!`. This removes one output-sized allocation per contraction: a contraction whose output needs a non-trivial permutation drops from 5× to 4× the output size in temporaries, on par with ITensors and TensorOperations, with no change in results.