### PR TITLE
Multiply dense contraction results directly into the destination

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/contract/contract_matricize.jl
+++ b/src/contract/contract_matricize.jl
@@ -1,3 +1,5 @@
+using LinearAlgebra: mul!
+
 function contractopadd!(
         algorithm::Matricize,
         a_dest::AbstractArray, biperm_dest_codomain, biperm_dest_domain,
@@ -18,10 +20,16 @@ function contractopadd!(
         matricizeop(algorithm.left_fusion_style, op1, a1, biperm1_codomain, biperm1_domain)
     a2_mat =
         matricizeop(algorithm.right_fusion_style, op2, a2, biperm2_codomain, biperm2_domain)
-    a_dest_mat = a1_mat * a2_mat
-    unmatricizeadd!(
-        algorithm.output_fusion_style, a_dest, a_dest_mat, invperm_codomain, invperm_domain,
-        α, β
-    )
+    output_style = algorithm.output_fusion_style
+    # Matricize the destination and multiply straight into it: a no-op for an aligned or
+    # transposed dense output (a view aliasing `a_dest`, so `mul!` writes through and we
+    # are done), a fresh permuted copy otherwise. Either way `matricize` seeds `a_dest_mat`
+    # with `a_dest`'s current contents, so `β` rides on the `mul!` and a detached copy is
+    # written back with a plain overwrite.
+    a_dest_mat = matricize(output_style, a_dest, invperm_codomain, invperm_domain)
+    mul!(a_dest_mat, a1_mat, a2_mat, α, β)
+    if !Base.mightalias(a_dest_mat, a_dest)
+        unmatricize!(output_style, a_dest, a_dest_mat, invperm_codomain, invperm_domain)
+    end
     return a_dest
 end

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -364,33 +364,6 @@ function unmatricize!(
     return bipermutedims!(a_dest, a_perm, biperm_dest)
 end
 
-function unmatricizeadd!(
-        a_dest::AbstractArray, m::AbstractMatrix,
-        invperm_codomain::Tuple{Vararg{Int}}, invperm_domain::Tuple{Vararg{Int}},
-        α::Number, β::Number
-    )
-    return unmatricizeadd!(
-        FusionStyle(a_dest), a_dest, m, invperm_codomain, invperm_domain, α, β
-    )
-end
-function unmatricizeadd!(
-        style::FusionStyle, a_dest::AbstractArray, m::AbstractMatrix,
-        invperm_codomain::Tuple{Vararg{Int}}, invperm_domain::Tuple{Vararg{Int}},
-        α::Number, β::Number
-    )
-    invbiperm = BiTuple(invperm_codomain, invperm_domain)
-    ndims(a_dest) == length(invbiperm) ||
-        throw(ArgumentError("destination does not match permutation"))
-    # Reshape `m` to the destination's matricized axes (a view), then permute it
-    # straight into `a_dest` with accumulation in a single pass, rather than
-    # allocating a permuted copy and then adding it. Mirrors `unmatricize!`.
-    a_perm = unmatricize(style, m, bipartition(axes(a_dest), invbiperm)...)
-    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(axes(a_dest))))
-    return bipermutedimsopadd!(
-        a_dest, identity, a_perm, biperm_dest.t1, biperm_dest.t2, α, β
-    )
-end
-
 # Defaults to ReshapeFusion, a simple reshape
 struct ReshapeFusion <: FusionStyle end
 FusionStyle(::Type{<:AbstractArray}) = ReshapeFusion()


### PR DESCRIPTION
## Summary

Multiplies the dense contraction result straight into its destination instead of through a separate temporary. The matricize-then-gemm path used to allocate the matrix product into a fresh array and then permute-and-accumulate it into the destination. It now matricizes the destination, multiplies into it in place with `mul!`, and writes back only when the matricized destination is a detached copy.

That decision is a runtime `Base.mightalias` check on the result. Whether `matricize` returns a view or a copy depends on the fusion style, the array type, and the permutation, so the alias check observes what `matricize` actually returned and stays correct for every fusion style without having to predict it. An aligned or transposed dense output matricizes to a view, and `mul!` writes through it with no product temporary. A permuted output, or any graded gather, matricizes to a fresh copy seeded with the destination's current contents, so the `β` accumulation rides on the `mul!` and the write-back is a plain overwrite.

For aligned and transposed contractions this removes both the product temporary and the scatter, dropping allocation to roughly the result alone. A square matmul at bond dimension 64 falls from about 71 KiB to 38.5 KiB per call. Genuinely permuted outputs are unchanged.

With the scatter gone, the `unmatricizeadd!` interface it relied on has no remaining caller and is removed. It was an unexported internal name, so this is non-breaking.

This builds on the maybe-view `matricize` from https://github.com/ITensor/TensorAlgebra.jl/pull/183, which is what lets `mul!` write through an aligned or transposed destination.
