### PR TITLE
Drop the real-eltype short-circuit in `conj` broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/linearbroadcasted.jl
+++ b/src/linearbroadcasted.jl
@@ -227,7 +227,6 @@ linearbroadcasted(::typeof(*), α::Number, a::ConjBroadcasted) = ScaledBroadcast
 
 # Conjugation.
 linearbroadcasted(::typeof(conj), a::AbstractArray) = ConjBroadcasted(a)
-linearbroadcasted(::typeof(conj), a::AbstractArray{<:Real}) = a
 linearbroadcasted(::typeof(conj), a::ConjBroadcasted) = unconj(a)
 function linearbroadcasted(::typeof(conj), a::ScaledBroadcasted)
     return ScaledBroadcasted(conj(coeff(a)), linearbroadcasted(conj, unscaled(a)))


### PR DESCRIPTION
## Summary

Drops the `linearbroadcasted(conj, ::AbstractArray{<:Real})` method that returned its argument unchanged. The method assumed a real element type means `conj` is a no-op, which holds for plain numeric arrays but not for arrays whose `conj` acts on structure rather than data. A graded or sector array with real entries still dualizes its axes and can pick up a fermionic reversal sign under `conj`, and the short-circuit silently dropped that, so `conj.(a)` disagreed with `conj(a)` for real-eltype fermionic arrays. Real arrays now take the same `ConjBroadcasted` path as everything else, which conjugates element-wise (a no-op on real data) and returns a fresh array.

Surfaces in https://github.com/ITensor/GradedArrays.jl/pull/185, where real-eltype fermionic `conj.(a)` lost its reversal sign.
