### PR TITLE
Add lazy `ConjArray` conjugation wrapper, replacing `ConjBroadcasted`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/TensorAlgebra.jl
+++ b/src/TensorAlgebra.jl
@@ -8,7 +8,7 @@ export contract, contract!, eig_full, eig_trunc, eig_vals, eigh_full, eigh_trunc
 if VERSION >= v"1.11.0-DEV.469"
     eval(
         Meta.parse(
-            "public biperm, bipartition, contractopadd!, matricizeop, zero!, scale!, permuteddims"
+            "public biperm, bipartition, contractopadd!, matricizeop, zero!, scale!, permuteddims, conjed, ConjArray"
         )
     )
 end
@@ -17,6 +17,7 @@ include("inplace.jl")
 include("MatrixAlgebra.jl")
 include("bituple.jl")
 include("permutedimsadd.jl")
+include("conjarray.jl")
 include("matricize.jl")
 include("contract/contractalgorithm.jl")
 include("contract/contract.jl")

--- a/src/conjarray.jl
+++ b/src/conjarray.jl
@@ -1,0 +1,62 @@
+# Lazy conjugated-array wrapper, mirroring `Adjoint`/`adjoint`. `conjed(a)` is the
+# friendly lazy companion to the eager `conj(a)`. The op primitives absorb a `ConjArray`
+# by unwrapping to the parent and folding `conj` into `op` (see `bipermutedimsopadd!`
+# below), so conjugation flows through broadcasting, contraction, and matricize uniformly.
+
+"""
+    ConjArray(a::AbstractArray)
+
+Lazy conjugate of `a`: an `AbstractArray` whose axes are the conjugated parent axes and
+whose elements are the conjugated parent elements. Constructed by [`conjed`](@ref). The op
+primitives absorb it by unwrapping to the parent and folding `conj` into their `op`.
+"""
+struct ConjArray{T, N, P <: AbstractArray{T, N}} <: AbstractArray{T, N}
+    parent::P
+end
+
+"""
+    conjed(a::AbstractArray)
+
+Lazy conjugate of `a`, returning a `ConjArray`. The lazy companion to the eager `conj(a)`,
+mirroring `adjoint`/`Adjoint`. `conjed(conjed(a))` returns `a`.
+"""
+conjed(a::AbstractArray) = ConjArray(a)
+conjed(a::ConjArray) = parent(a)
+
+Base.parent(a::ConjArray) = a.parent
+
+# `conj` of an axis: dualizes graded axes, identity for plain ranges (Base `conj` on a
+# range broadcasts to a vector, so we cannot call it directly). Overridable downstream.
+conjaxis(r) = r
+
+Base.axes(a::ConjArray) = map(conjaxis, axes(parent(a)))
+Base.size(a::ConjArray) = size(parent(a))
+
+Base.IndexStyle(::Type{<:ConjArray{<:Any, <:Any, P}}) where {P} = IndexStyle(P)
+Base.getindex(a::ConjArray, I::Int...) = conj(parent(a)[I...])
+
+# Absorb a `ConjArray` source by unwrapping to the parent and folding `conj` into `op`
+# (`identity -> conj`, `conj -> identity`). Mirrors the `PermutedDimsArray` absorption,
+# which instead folds its permutation into `perm`.
+function bipermutedimsopadd!(
+        dest::AbstractArray, op, src::ConjArray,
+        perm_codomain, perm_domain,
+        α::Number, β::Number
+    )
+    return bipermutedimsopadd!(
+        dest, _compose_op(op, conj), parent(src),
+        perm_codomain, perm_domain,
+        α, β
+    )
+end
+
+# Materialize eagerly through the op primitive, so the conjugation (and any parent-specific
+# behavior such as a graded fermion sign) is applied by the same `op = conj` path the
+# primitives use everywhere else. `copy(conjed(a))` for a plain `Array` is `conj(a)`.
+Base.copy(a::ConjArray) = add!(similar(parent(a), eltype(a), axes(a)), a, true, false)
+Base.Broadcast.materialize(a::ConjArray) = copy(a)
+
+# Broadcast like the parent (e.g. preserve a graded style), not the default array style.
+function Base.Broadcast.BroadcastStyle(::Type{<:ConjArray{<:Any, <:Any, P}}) where {P}
+    return Base.Broadcast.BroadcastStyle(P)
+end

--- a/src/conjarray.jl
+++ b/src/conjarray.jl
@@ -25,11 +25,9 @@ conjed(a::ConjArray) = parent(a)
 
 Base.parent(a::ConjArray) = a.parent
 
-# `conj` of an axis: dualizes graded axes, identity for plain ranges (Base `conj` on a
-# range broadcasts to a vector, so we cannot call it directly). Overridable downstream.
-conjaxis(r) = r
-
-Base.axes(a::ConjArray) = map(conjaxis, axes(parent(a)))
+# Conjugating an axis is identity for plain integer ranges and dualizes graded axes (where
+# `conj` is overloaded as `dual` downstream).
+Base.axes(a::ConjArray) = map(conj, axes(parent(a)))
 Base.size(a::ConjArray) = size(parent(a))
 
 Base.IndexStyle(::Type{<:ConjArray{<:Any, <:Any, P}}) where {P} = IndexStyle(P)

--- a/src/conjarray.jl
+++ b/src/conjarray.jl
@@ -54,6 +54,7 @@ end
 # behavior such as a graded fermion sign) is applied by the same `op = conj` path the
 # primitives use everywhere else. `copy(conjed(a))` for a plain `Array` is `conj(a)`.
 Base.copy(a::ConjArray) = add!(similar(parent(a), eltype(a), axes(a)), a, true, false)
+Base.copyto!(dest::AbstractArray, src::ConjArray) = add!(dest, src, true, false)
 Base.Broadcast.materialize(a::ConjArray) = copy(a)
 
 # Broadcast like the parent (e.g. preserve a graded style), not the default array style.

--- a/src/linearbroadcasted.jl
+++ b/src/linearbroadcasted.jl
@@ -65,20 +65,10 @@ Base.ndims(a::ScaledBroadcasted) = ndims(unscaled(a))
 operation(::ScaledBroadcasted) = *
 arguments(a::ScaledBroadcasted) = (coeff(a), unscaled(a))
 
-# --- ConjBroadcasted ----------------------------------------------------------
-
-struct ConjBroadcasted{A} <: LinearBroadcasted
-    parent::A
-end
-
-unconj(a::ConjBroadcasted) = a.parent
-
-Base.axes(a::ConjBroadcasted) = axes(unconj(a))
-Base.eltype(a::ConjBroadcasted) = eltype(unconj(a))
-Base.ndims(a::ConjBroadcasted) = ndims(unconj(a))
-
-operation(::ConjBroadcasted) = conj
-arguments(a::ConjBroadcasted) = (unconj(a),)
+# Conjugation is represented by the `ConjArray` lazy wrapper (a real `AbstractArray` with
+# conjugated axes), not a dedicated `LinearBroadcasted` node. The lowering below produces
+# `ConjArray` leaves, and the op primitives absorb them by folding `conj` into `op` (see
+# `conjarray.jl`).
 
 # --- AddBroadcasted -----------------------------------------------------------
 
@@ -170,12 +160,6 @@ function permutedimsopadd!(
 end
 
 function permutedimsopadd!(
-        dest::AbstractArray, op, src::ConjBroadcasted, perm, α::Number, β::Number
-    )
-    return permutedimsopadd!(dest, _compose_op(op, conj), unconj(src), perm, α, β)
-end
-
-function permutedimsopadd!(
         dest::AbstractArray, op, src::AddBroadcasted, perm, α::Number, β::Number
     )
     args = addends(src)
@@ -208,7 +192,7 @@ Analogous to `Base.Broadcast.broadcasted(f, args...)`.
 
 ```julia
 linearbroadcasted(*, 2.0, a)   # ScaledBroadcasted(2.0, a)
-linearbroadcasted(conj, a)     # ConjBroadcasted(a)
+linearbroadcasted(conj, a)     # ConjArray(a)
 linearbroadcasted(+, a, b)     # AddBroadcasted(a, b)
 ```
 """
@@ -221,13 +205,10 @@ linearbroadcasted(::typeof(*), a::AbstractArray, α::Number) = ScaledBroadcasted
 function linearbroadcasted(::typeof(*), α::Number, a::ScaledBroadcasted)
     return ScaledBroadcasted(α * coeff(a), unscaled(a))
 end
-# Scaling of ConjBroadcasted (e.g. `conj.(a) ./ β`): the scaling factor materializes via
-# `ScaledBroadcasted`, which composes with the inner conjugation.
-linearbroadcasted(::typeof(*), α::Number, a::ConjBroadcasted) = ScaledBroadcasted(α, a)
-
-# Conjugation.
-linearbroadcasted(::typeof(conj), a::AbstractArray) = ConjBroadcasted(a)
-linearbroadcasted(::typeof(conj), a::ConjBroadcasted) = unconj(a)
+# Conjugation lowers to the `ConjArray` lazy wrapper. A scaled `ConjArray` (e.g.
+# `conj.(a) ./ β`) is handled by the generic `AbstractArray` scaling method above, since
+# `ConjArray <: AbstractArray`.
+linearbroadcasted(::typeof(conj), a::AbstractArray) = conjed(a)
 function linearbroadcasted(::typeof(conj), a::ScaledBroadcasted)
     return ScaledBroadcasted(conj(coeff(a)), linearbroadcasted(conj, unscaled(a)))
 end
@@ -355,9 +336,6 @@ end
 
 # BroadcastStyle for LinearBroadcasted subtypes — delegate to the wrapped array type.
 function BC.BroadcastStyle(::Type{<:ScaledBroadcasted{<:Any, A}}) where {A}
-    return BC.BroadcastStyle(A)
-end
-function BC.BroadcastStyle(::Type{<:ConjBroadcasted{A}}) where {A}
     return BC.BroadcastStyle(A)
 end
 function BC.BroadcastStyle(::Type{<:AddBroadcasted{Args}}) where {Args}

--- a/test/test_conjarray.jl
+++ b/test/test_conjarray.jl
@@ -1,0 +1,52 @@
+using TensorAlgebra: TensorAlgebra as TA, ConjArray, bipermutedimsopadd!, conjed
+using Test: @test, @testset
+
+@testset "ConjArray (plain arrays)" begin
+    a = randn(ComplexF64, 3, 4)
+
+    c = conjed(a)
+    @test c isa ConjArray
+    @test parent(c) === a
+    @test conjed(c) === a            # involution unwraps, no nesting
+    @test eltype(c) === eltype(a)
+    @test ndims(c) == 2
+    @test size(c) == size(a)
+    @test axes(c) == axes(a)         # plain axes are unchanged by conj
+
+    # Indexing and materialization match eager conj of the parent.
+    @test c[2, 3] == conj(a[2, 3])
+    @test collect(c) == conj(a)
+
+    # Real eltype: conj is a value no-op, but the wrapper still wraps.
+    r = randn(Float64, 2, 2)
+    cr = conjed(r)
+    @test cr isa ConjArray
+    @test collect(cr) == r
+    @test axes(cr) == axes(r)
+end
+
+@testset "ConjArray composes with PermutedDimsArray" begin
+    a = randn(ComplexF64, 2, 3, 4, 5)
+    w = (3, 1, 4, 2)
+
+    # ConjArray outside, PermutedDimsArray inside, and vice versa.
+    c_out = ConjArray(PermutedDimsArray(a, w))
+    c_in = PermutedDimsArray(ConjArray(a), w)
+    @test collect(c_out) == conj(permutedims(a, w))
+    @test copy(c_out) ≈ conj(permutedims(a, w))
+    @test collect(c_in) == permutedims(conj(a), w)
+
+    # Both unwrap through bipermutedimsopadd! (the nested wrappers fold into op and perm).
+    for (pc, pd) in (((1, 2, 3, 4), ()), ((2, 4), (1, 3)))
+        perm = (pc..., pd...)
+        ref_out = permutedims(conj(permutedims(a, w)), perm)
+        dest = zeros(ComplexF64, size(ref_out)...)
+        bipermutedimsopadd!(dest, identity, c_out, pc, pd, true, false)
+        @test dest ≈ ref_out
+
+        ref_in = permutedims(permutedims(conj(a), w), perm)
+        dest = zeros(ComplexF64, size(ref_in)...)
+        bipermutedimsopadd!(dest, identity, c_in, pc, pd, true, false)
+        @test dest ≈ ref_in
+    end
+end

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -35,7 +35,7 @@ using Test: @test, @testset
             exports,
             [
                 :biperm, :bipartition, :contractopadd!, :matricizeop, :zero!,
-                :scale!, :permuteddims,
+                :scale!, :permuteddims, :conjed, :ConjArray,
             ]
         )
     end

--- a/test/test_linearbroadcasted.jl
+++ b/test/test_linearbroadcasted.jl
@@ -13,7 +13,7 @@ using Test: @test, @test_throws, @testset
         @test copy(x) ≈ 2a
 
         x = linearbroadcasted(conj, a)
-        @test x ≡ TA.ConjBroadcasted(a)
+        @test x ≡ TA.ConjArray(a)
         @test copy(x) ≈ conj(a)
 
         x = linearbroadcasted(+, a, b)
@@ -64,7 +64,7 @@ using Test: @test, @test_throws, @testset
 
         # Conjugation of scaled
         x = linearbroadcasted(conj, linearbroadcasted(*, 2im, a))
-        @test x ≡ TA.ScaledBroadcasted(-2im, TA.ConjBroadcasted(a))
+        @test x ≡ TA.ScaledBroadcasted(-2im, TA.ConjArray(a))
 
         # Double conjugation cancels
         @test linearbroadcasted(conj, linearbroadcasted(conj, a)) ≡ a
@@ -160,7 +160,7 @@ using Test: @test, @test_throws, @testset
         TA.add!(dest, linearbroadcasted(+, a, b), true, false)
         @test dest ≈ a + b
 
-        # add! with ConjBroadcasted
+        # add! with a ConjArray
         dest = zeros(ComplexF64, 3, 3)
         TA.add!(dest, linearbroadcasted(conj, a), true, false)
         @test dest ≈ conj(a)

--- a/test/test_permutedimsadd.jl
+++ b/test/test_permutedimsadd.jl
@@ -1,6 +1,7 @@
 using Adapt: adapt
 using JLArrays: JLArray
-using TensorAlgebra: add!, bipermutedimsopadd!, permutedimsadd!, permutedimsopadd!
+using TensorAlgebra:
+    ConjArray, add!, bipermutedimsopadd!, conjed, permutedimsadd!, permutedimsopadd!
 using Test: @test, @testset
 
 @testset "[permutedims]add!" begin
@@ -65,6 +66,50 @@ using Test: @test, @testset
                 bipermutedimsopadd!(dest′, identity, src, pc, pd, 2, β)
                 @test dest′ ≈ β * dest + 2 * ref
             end
+        end
+    end
+    @testset "bipermutedimsopadd! unwraps ConjArray src (arraytype=$arrayt)" for arrayt in
+        (
+            Array,
+            JLArray,
+        )
+        dev = adapt(arrayt)
+        parent = dev(randn(ComplexF64, 2, 3, 4, 5))
+        src = ConjArray(parent)
+        for (pc, pd) in (((1, 2, 3, 4), ()), ((2, 4), (1, 3)), ((3, 1), (2, 4)))
+            perm = (pc..., pd...)
+            # `op = identity` composes with the wrapper's `conj`: result is the conjugated,
+            # permuted parent.
+            ref_conj = permutedims(conj(parent), perm)
+            # `op = conj` cancels the wrapper's `conj`: result is the bare permuted parent.
+            ref_id = permutedims(parent, perm)
+            for β in (0, 3)
+                dest = dev(randn(ComplexF64, size(ref_conj)...))
+                dest′ = copy(dest)
+                bipermutedimsopadd!(dest′, identity, src, pc, pd, 2, β)
+                @test dest′ ≈ β * dest + 2 * ref_conj
+
+                dest′ = copy(dest)
+                bipermutedimsopadd!(dest′, conj, src, pc, pd, 2, β)
+                @test dest′ ≈ β * dest + 2 * ref_id
+            end
+        end
+    end
+    @testset "add!(b, conjed(a)) matches eager conj (arraytype=$arrayt)" for arrayt in
+        (
+            Array,
+            JLArray,
+        )
+        dev = adapt(arrayt)
+        a = dev(randn(ComplexF64, 2, 3, 4))
+        α = 2
+        for β in (0, 3)
+            b = dev(randn(ComplexF64, 2, 3, 4))
+            b_lazy = copy(b)
+            b_eager = copy(b)
+            add!(b_lazy, conjed(a), α, β)
+            add!(b_eager, conj(a), α, β)
+            @test b_lazy ≈ b_eager
         end
     end
     @testset "bipermutedimsopadd! 0-dim with β=0 must not read dest (eltype=$T)" for T in


### PR DESCRIPTION
## Summary

Adds `ConjArray`, a lazy conjugated-array wrapper, and the `conjed` constructor, the lazy companion to the eager `conj` and mirroring `Adjoint`/`adjoint`. `conjed(a)` wraps `a` in a `ConjArray` whose axes are the conjugated parent axes and whose elements are the conjugated parent elements, and `conjed(conjed(a))` returns `a`.

The op primitives absorb a `ConjArray` source by unwrapping to the parent and folding `conj` into their `op` (`identity` becomes `conj`, `conj` becomes `identity`), the same unwrap-and-fold pattern already used for `PermutedDimsArray`. Because the primitives are the common path, conjugation flows through broadcasting, contraction, and matricize with one mechanism, and a `ConjArray` composes with a `PermutedDimsArray` in either nesting order.

Representing conjugation as a real `AbstractArray` with conjugated axes lets the broadcast lowering produce `ConjArray` leaves, and lets the standard axis-combining machinery compare the post-conjugation axes directly. That makes the dedicated `ConjBroadcasted` linear-broadcast node redundant, so it is removed.

A follow-up GradedArrays PR (https://github.com/ITensor/GradedArrays.jl/pull/190) routes its `conj` through this wrapper, where conjugating an axis dualizes it. The wrapper conjugates each parent axis with `conj`, which is the identity on plain integer ranges and is overloaded as the dual downstream.
