### PR TITLE
Add a `to_range` interface for building ranges from length specs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.12.3"
+version = "0.12.4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/TensorAlgebra.jl
+++ b/src/TensorAlgebra.jl
@@ -8,7 +8,7 @@ export contract, contract!, eig_full, eig_trunc, eig_vals, eigh_full, eigh_trunc
 if VERSION >= v"1.11.0-DEV.469"
     eval(
         Meta.parse(
-            "public biperm, bipartition, contractopadd!, matricizeop, zero!, scale!, permuteddims, conjed, ConjArray"
+            "public biperm, bipartition, contractopadd!, matricizeop, to_range, zero!, scale!, permuteddims, conjed, ConjArray"
         )
     )
 end
@@ -19,6 +19,7 @@ include("bituple.jl")
 include("permutedimsadd.jl")
 include("conjarray.jl")
 include("matricize.jl")
+include("to_range.jl")
 include("contract/contractalgorithm.jl")
 include("contract/contract.jl")
 include("contract/contract_labels.jl")

--- a/src/to_range.jl
+++ b/src/to_range.jl
@@ -1,0 +1,15 @@
+"""
+    TensorAlgebra.to_range(space)
+
+Convert a description of a space into a default range type, returning the range unchanged
+if it already is one. This lets range and axis constructors accept a space uniformly
+instead of each reimplementing the conversion.
+
+  - an `Integer` length -> `Base.OneTo`
+  - an existing `AbstractUnitRange` -> itself (idempotent passthrough)
+
+Downstream packages extend this for richer spaces; for example, GradedArrays adds a method
+that turns a vector of sector-to-multiplicity pairs into a graded range.
+"""
+to_range(space::AbstractUnitRange) = space
+to_range(space::Integer) = Base.OneTo(space)

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -34,8 +34,8 @@ using Test: @test, @testset
         append!(
             exports,
             [
-                :biperm, :bipartition, :contractopadd!, :matricizeop, :zero!,
-                :scale!, :permuteddims, :conjed, :ConjArray,
+                :biperm, :bipartition, :contractopadd!, :matricizeop, :to_range,
+                :zero!, :scale!, :permuteddims, :conjed, :ConjArray,
             ]
         )
     end

--- a/test/test_to_range.jl
+++ b/test/test_to_range.jl
@@ -1,0 +1,15 @@
+using TensorAlgebra: TensorAlgebra
+using Test: @test, @testset
+
+@testset "to_range" begin
+    @testset "Integer -> Base.OneTo" begin
+        r = TensorAlgebra.to_range(3)
+        @test r === Base.OneTo(3)
+    end
+
+    @testset "range passthrough is idempotent" begin
+        for r in (Base.OneTo(4), 2:5)
+            @test TensorAlgebra.to_range(r) === r
+        end
+    end
+end


### PR DESCRIPTION
## Summary

Adds `to_range`, which converts a description of a space into a default range type: an `Integer` becomes a `Base.OneTo`, and an existing range is returned unchanged. Range and axis constructors can route their argument through it instead of each reimplementing the conversion. It is marked `public` and declared here with the non-graded defaults. Downstream packages extend it, for example GradedArrays adds a method that turns a vector of sector-to-multiplicity pairs into a graded range.