### PR TITLE
Drop a per-call closure allocation in the bipermutedimsopadd! axis check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.14.0"
+version = "0.14.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/permutedimsadd.jl
+++ b/src/permutedimsadd.jl
@@ -28,7 +28,7 @@ function check_input(
     perm = (perm_codomain..., perm_domain...)
     ndims(dest) == length(perm) ||
         throw(DimensionMismatch("destination ndims does not match permutation length"))
-    axes(dest) == ntuple(d -> op(axes(src, perm[d])), ndims(dest)) ||
+    axes(dest) == map(p -> op(axes(src, p)), perm) ||
         throw(DimensionMismatch("destination axes do not match permuted source axes"))
     return nothing
 end


### PR DESCRIPTION
## Summary

Removes a per-call heap allocation in `check_input` for `bipermutedimsopadd!`. The axis check built its comparison tuple with `ntuple(d -> op(axes(src, perm[d])), ndims(dest))`, whose index closure captures runtime values (`op`, `src`, `perm`) and so is heap-allocated on every call. Mapping over the permutation tuple directly with `map(p -> op(axes(src, p)), perm)` is unrolled over the concrete tuple and allocates nothing, and is equivalent because `ndims(dest) == length(perm)` is already checked just above. A 2x2 `permutedimsadd!` drops from 2 allocations (64 B) to 1 (16 B).