### PR TITLE
Add `data` for TensorKit tensor maps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/ext/TensorAlgebraTensorKitExt.jl
+++ b/ext/TensorAlgebraTensorKitExt.jl
@@ -3,9 +3,9 @@ module TensorAlgebraTensorKitExt
 using MatrixAlgebraKit: diagview
 using Random: AbstractRNG
 using TensorAlgebra: TensorAlgebra
-using TensorKit: TensorKit, AbstractTensorMap, ElementarySpace, ProductSpace,
-    TensorMapWithStorage, blocks, codomain, dim, domain, dual, fuse, numind, permute,
-    project_symmetric!, sectors, space, spacetype, zerovector!, ←
+using TensorKit: TensorKit, AbstractTensorMap, DiagonalTensorMap, ElementarySpace,
+    ProductSpace, TensorMap, TensorMapWithStorage, blocks, codomain, dim, domain, dual,
+    fuse, numind, permute, project_symmetric!, sectors, space, spacetype, zerovector!, ←
 using TensorOperations: TensorOperations as TO
 
 # ============================  AbstractArray-vocabulary bridge  ============================
@@ -24,6 +24,15 @@ TensorAlgebra.size(t::AbstractTensorMap) = ntuple(i -> dim(space(t, i)), numind(
 # `t[]` on a rank-0 `TensorMap` requires a trivial sector type; `TensorKit.scalar` is the
 # general spelling.
 TensorAlgebra.scalar(t::AbstractTensorMap) = TensorKit.scalar(t)
+
+# `data`/`datatype` reach the underlying storage array. A `TensorMap`/`DiagonalTensorMap` owns its
+# storage as the flat block vector `t.data` (a `DenseVector`, type `storagetype(t)`), but is not an
+# `AbstractArray`, so the generic `data` recursion (which follows `Base.parent`) has no way in.
+# Route it into the storage vector and keep recursing, so any wrapper on that vector is unwrapped
+# to the true leaf. A lazy `AdjointTensorMap` defines `Base.parent`, so the generic recursion
+# already unwraps it; a general `AbstractTensorMap` has no single storage vector, so gets no method.
+TensorAlgebra.data(t::TensorMap) = TensorAlgebra.data(t.data)
+TensorAlgebra.data(t::DiagonalTensorMap) = TensorAlgebra.data(t.data)
 
 # The trivial length-1 axis of a space is its unit space (`oneunit`), the trivial-sector
 # one-dimensional space; the length-`n` form is the direct sum of `n` unit spaces.

--- a/test/test_tensorkitext.jl
+++ b/test/test_tensorkitext.jl
@@ -4,8 +4,8 @@ using StableRNGs: StableRNG
 using TensorAlgebra: TensorAlgebra, contract, matricize, project, projectto!, rand_map,
     randn_map, similar_map, tryflattenlinear, tryproject, unchecked_project, unmatricize,
     zeros_map
-using TensorKit: @tensor, AbstractTensorMap, Rep, SU₂, TensorMap, U₁, dim, dual, fuse,
-    isomorphism, randn, space, storagetype, ←, ⊗
+using TensorKit: @tensor, AbstractTensorMap, DiagonalTensorMap, Rep, SU₂, TensorMap, U₁,
+    dim, dual, fuse, isomorphism, randn, reduceddim, space, storagetype, ←, ⊗
 using Test: @test, @test_throws, @testset
 
 # A shared bond contracts when it sits in one operand's domain and the other's codomain, i.e.
@@ -298,6 +298,23 @@ using Test: @test, @test_throws, @testset
         # A nonlinear (element-wise) broadcast is not expressible as a `LinearBroadcasted`.
         @test isnothing(tryflattenlinear(broadcasted(*, a, b)))
         @test_throws ErrorException copy(broadcasted(*, a, b))
+    end
+
+    @testset "data / datatype (storage vector)" begin
+        W = Rep[U₁](0 => 2, 1 => 1)
+        X = Rep[U₁](0 => 1, 1 => 2)
+        t = randn(rng, elt, W, X)
+        # `data` reaches the underlying storage vector, and `datatype` is its type (`storagetype`).
+        @test TensorAlgebra.data(t) === t.data
+        @test TensorAlgebra.datatype(t) === storagetype(t) === typeof(t.data)
+        # A lazy adjoint shares its parent's storage vector; the generic `data` recursion follows
+        # `Base.parent` down to it, so no dedicated adjoint method is needed.
+        @test TensorAlgebra.data(t') === t.data
+        @test TensorAlgebra.datatype(t') === storagetype(t)
+        # A `DiagonalTensorMap` is also a storage-owning leaf.
+        d = DiagonalTensorMap(randn(rng, elt, reduceddim(W)), W)
+        @test TensorAlgebra.data(d) === d.data
+        @test TensorAlgebra.datatype(d) === storagetype(d)
     end
 
     @testset "ungrade / tr" begin


### PR DESCRIPTION
## Summary

Adds a `TensorAlgebra.data` method for `TensorMap` and `DiagonalTensorMap` in the TensorKit extension, so `data` and `datatype` resolve for TensorKit-backed tensors. A `TensorMap` is not an `AbstractArray`, so it has no `Base.parent(::AbstractArray)` self-fallback for the generic `data` recursion to reach, and the recursion had no leaf to bottom out on. The methods route into the flat block storage vector `t.data` (type `storagetype(t)`) and keep recursing through `data`, so any wrapper on that vector is unwrapped to the true leaf. A lazy `AdjointTensorMap` already defines `Base.parent`, so the generic recursion unwraps it with no dedicated method, and a general `AbstractTensorMap` has no single storage vector, so gets no method.