### PR TITLE
Route TensorMap in-place linear algebra through VectorInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -19,10 +19,11 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
+VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 
 [extensions]
 TensorAlgebraMooncakeExt = "Mooncake"
-TensorAlgebraTensorKitExt = ["TensorKit", "TensorOperations"]
+TensorAlgebraTensorKitExt = ["TensorKit", "TensorOperations", "VectorInterface"]
 TensorAlgebraTensorOperationsExt = "TensorOperations"
 
 [compat]
@@ -36,4 +37,5 @@ StridedViews = "0.5"
 TensorKit = "0.17"
 TensorOperations = "5"
 TupleTools = "1.6"
+VectorInterface = "0.4.8, 0.5"
 julia = "1.10"

--- a/ext/TensorAlgebraTensorKitExt.jl
+++ b/ext/TensorAlgebraTensorKitExt.jl
@@ -5,8 +5,9 @@ using Random: AbstractRNG
 using TensorAlgebra: TensorAlgebra
 using TensorKit: TensorKit, AbstractTensorMap, DiagonalTensorMap, ElementarySpace,
     ProductSpace, TensorMap, TensorMapWithStorage, blocks, codomain, dim, domain, dual,
-    fuse, numind, permute, project_symmetric!, sectors, space, spacetype, zerovector!, ←
+    fuse, numind, permute, project_symmetric!, sectors, space, spacetype, ←
 using TensorOperations: TensorOperations as TO
+using VectorInterface: VectorInterface
 
 # ============================  AbstractArray-vocabulary bridge  ============================
 # TensorAlgebra's generic orchestration describes operands in the `AbstractArray` vocabulary
@@ -282,7 +283,18 @@ end
 # there: `zero!` clears the `similar_map`-allocated destination, and the default algorithm
 # hands the in-place contraction to the TensorOperations backend (see the TensorOperations
 # extension's `contractopadd!`).
-TensorAlgebra.zero!(t::AbstractTensorMap) = zerovector!(t)
+TensorAlgebra.zero!(t::AbstractTensorMap) = VectorInterface.zerovector!(t)
+
+# A `TensorMap` is not an `AbstractArray`, so the generic in-place `TensorAlgebra` operations
+# don't apply. Forward to TensorKit's `VectorInterface` methods, its primary interface for these.
+# `add!` here is the non-permuting `y = α*x + β*y`. The permuting `bipermutedimsopadd!` handles a
+# non-trivial codomain/domain permutation.
+TensorAlgebra.scale!(t::AbstractTensorMap, β::Number) = VectorInterface.scale!(t, β)
+function TensorAlgebra.add!(
+        y::AbstractTensorMap, x::AbstractTensorMap, α::Number, β::Number
+    )
+    return VectorInterface.add!(y, x, α, β)
+end
 
 function TensorAlgebra.default_contract_algorithm(
         ::Type{<:AbstractTensorMap}, ::Type{<:AbstractTensorMap}


### PR DESCRIPTION
## Summary

Defines `TensorAlgebra.zero!`, `scale!`, and `add!` for `AbstractTensorMap` as thin forwards to the corresponding `VectorInterface` methods, which are TensorKit's primary interface for these in-place linear operations. The generic `AbstractArray` definitions don't apply, since a `TensorMap` is not an `AbstractArray`, and routing through `VectorInterface` keeps a self-aliased call such as `a .*= 2` or `add!(a, a, α, β)` a correct block-wise rescale instead of aliasing the destination with an operand through a broadcast. The `add!` method here is the non-permuting `y = α*x + β*y`. The permuting `bipermutedimsopadd!` still fuses a non-trivial codomain/domain permutation for the matricize, contract, and broadcast callers.

`VectorInterface` becomes a weak dependency on the TensorKit extension's trigger list. It is already a dependency of TensorKit, so loading TensorKit pulls it in and the effective load trigger is unchanged.
