### PR TITLE
Add `unproject` to invert `project` given the codomain/domain split

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.17.5"
+version = "0.17.6"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/ext/TensorAlgebraTensorKitExt.jl
+++ b/ext/TensorAlgebraTensorKitExt.jl
@@ -5,7 +5,7 @@ using Random: AbstractRNG
 using TensorAlgebra: TensorAlgebra
 using TensorKit: TensorKit, AbstractTensorMap, DiagonalTensorMap, ElementarySpace,
     ProductSpace, TensorMap, TensorMapWithStorage, blocks, codomain, dim, domain, dual,
-    fuse, numind, permute, project_symmetric!, sectors, space, spacetype, ←
+    fuse, numind, numout, permute, project_symmetric!, sectors, space, spacetype, ←
 using TensorOperations: TensorOperations as TO
 using VectorInterface: VectorInterface
 
@@ -145,8 +145,16 @@ function TensorAlgebra.projectto!(dest::AbstractTensorMap, src::AbstractArray)
     return project_symmetric!(dest, reshape(src, TensorAlgebra.size(dest)))
 end
 
-# The `is_projected` check compares through `convert(Array, dest)`, which TensorKit already
-# defines for an `AbstractTensorMap`, so no dedicated method is needed here.
+# A `TensorMap` carries its own split, so `unproject` is `convert(Array, t)`, only checking the
+# caller's split matches the map's codomain rank.
+function TensorAlgebra.unproject(t::AbstractTensorMap, ::Val{K}) where {K}
+    K == numout(t) || throw(
+        ArgumentError(
+            "`unproject`: codomain split Val($K) does not match the `TensorMap`'s codomain rank $(numout(t))"
+        )
+    )
+    return convert(Array, t)
+end
 
 # =============================  allocate_project (aux-leg derivation)  =====================
 # `allocate_project` for `TensorMap` spaces routes both the codomain-led and the (empty-codomain)

--- a/ext/TensorAlgebraTensorKitExt.jl
+++ b/ext/TensorAlgebraTensorKitExt.jl
@@ -21,6 +21,8 @@ TensorAlgebra.axes(t::AbstractTensorMap) = ntuple(i -> space(t, i), numind(t))
 # A `TensorMap` has no `Base.size`; its dense size is the per-index space dimension.
 TensorAlgebra.size(t::AbstractTensorMap, i::Int) = dim(space(t, i))
 TensorAlgebra.size(t::AbstractTensorMap) = ntuple(i -> dim(space(t, i)), numind(t))
+# A `TensorMap` stores its codomain/domain split, so its codomain rank is `numout`.
+TensorAlgebra.ndims_codomain(t::AbstractTensorMap) = numout(t)
 
 # `t[]` on a rank-0 `TensorMap` requires a trivial sector type; `TensorKit.scalar` is the
 # general spelling.

--- a/src/projectto.jl
+++ b/src/projectto.jl
@@ -64,31 +64,28 @@ end
 # applies to the flat all-codomain (state) form.
 unchecked_project(raw, axes) = unchecked_project(raw, axes, ())
 
+# The codomain rank a destination reports when no split is given: its full rank by default (no
+# domain), overloaded by a backend that stores a split (a `TensorMap` returns `numout`).
+ndims_codomain(a) = ndims(a)
+
 """
+    is_projected(dest, src, ndims_codomain::Val; kwargs...) -> Bool
     is_projected(dest, src; kwargs...) -> Bool
 
-Whether the projected `dest` still represents `src` within the `isapprox`
-tolerance, i.e. whether the projection that produced `dest` discarded only a
-negligible component of `src`. Keyword arguments are forwarded to `isapprox`.
+Whether the projected `dest` still represents `src` within the `isapprox` tolerance, i.e. whether
+the projection that produced `dest` discarded only a negligible component of `src`. Keyword
+arguments are forwarded to `isapprox`. Compares `src` against [`unproject`](@ref)`(dest, ndims_codomain)`, so a backend that changes basis in `project` is checked in the frame `src` was
+given in. The two-argument form uses the destination's own codomain rank.
 
-Together with [`unchecked_project`](@ref) this is the backend customization
-point ([`project`](@ref) and [`tryproject`](@ref) derive from the two). The
-generic method reshapes `src` to `size(dest)` up to trailing length-1 axes
-(so a lower-rank `src` that omits them lines up) and compares against
-`convert(Array, dest)`, so a backend whose arrays are not elementwise
-comparable to a dense array (opaque block storage, a `TensorMap`) only needs
-that conversion.
+Together with [`unchecked_project`](@ref) this is the backend customization point ([`project`](@ref)
+and [`tryproject`](@ref) derive from the two).
 """
-function is_projected(dest, src; kwargs...)
-    check_project_size(size(src), size(dest))
-    return isapprox(reshape(src, size(dest)), convert(Array, dest); kwargs...)
-end
-
-# Compare `src` against `unproject(dest, ndims_codomain)` rather than `convert(Array, dest)`, so a
-# backend that changes basis in `project` is checked in the frame `raw` was given in.
 function is_projected(dest, src, ndims_codomain::Val; kwargs...)
     check_project_size(size(src), size(dest))
     return isapprox(reshape(src, size(dest)), unproject(dest, ndims_codomain); kwargs...)
+end
+function is_projected(dest, src; kwargs...)
+    return is_projected(dest, src, Val(ndims_codomain(dest)); kwargs...)
 end
 
 """

--- a/src/projectto.jl
+++ b/src/projectto.jl
@@ -84,6 +84,24 @@ function is_projected(dest, src; kwargs...)
     return isapprox(reshape(src, size(dest)), convert(Array, dest); kwargs...)
 end
 
+# Compare `src` against `unproject(dest, ndims_codomain)` rather than `convert(Array, dest)`, so a
+# backend that changes basis in `project` is checked in the frame `raw` was given in.
+function is_projected(dest, src, ndims_codomain::Val; kwargs...)
+    check_project_size(size(src), size(dest))
+    return isapprox(reshape(src, size(dest)), unproject(dest, ndims_codomain); kwargs...)
+end
+
+"""
+    unproject(a, ndims_codomain::Val) -> raw
+
+Inverse of [`project`](@ref): recover the dense array that `project` maps to `a`, given the
+codomain/domain split `ndims_codomain` as a `Val`. The default is `convert(Array, a)`; a backend
+that changes basis in `project` overloads this to undo that change, so that
+
+    unproject(project(raw, codomain_axes, domain_axes), Val(length(codomain_axes))) ≈ raw
+"""
+unproject(a, ::Val) = convert(Array, a)
+
 """
     project!(dest, src; kwargs...) -> dest
 
@@ -125,7 +143,7 @@ domain.
 """
 function project(raw, codomain_axes, domain_axes; kwargs...)
     dest = unchecked_project(raw, codomain_axes, domain_axes)
-    is_projected(dest, raw; kwargs...) ||
+    is_projected(dest, raw, Val(length(codomain_axes)); kwargs...) ||
         throw(InexactError(:project, typeof(dest), raw))
     return dest
 end
@@ -147,6 +165,6 @@ Keyword arguments are forwarded to the `isapprox` tolerance check.
 """
 function tryproject(raw, codomain_axes, domain_axes; kwargs...)
     dest = unchecked_project(raw, codomain_axes, domain_axes)
-    return is_projected(dest, raw; kwargs...) ? dest : nothing
+    return is_projected(dest, raw, Val(length(codomain_axes)); kwargs...) ? dest : nothing
 end
 tryproject(raw, axes; kwargs...) = tryproject(raw, axes, (); kwargs...)

--- a/test/test_projectto.jl
+++ b/test/test_projectto.jl
@@ -1,5 +1,5 @@
 using TensorAlgebra: TensorAlgebra, is_projected, project, project!, projectto!, tryproject,
-    unchecked_project
+    unchecked_project, unproject
 using Test: @test, @test_throws, @testset
 
 const elts = (Float32, Float64, ComplexF32, ComplexF64)
@@ -80,6 +80,16 @@ end
     t = tryproject(raw, (Base.OneTo(2), Base.OneTo(3)))
     @test t == raw
     @test tryproject(raw, (Base.OneTo(2),), (Base.OneTo(3),)) == raw
+end
+
+@testset "unproject (dense default) ($T)" for T in elts
+    raw = randn(T, 2, 3, 2, 3)
+    cod = (Base.OneTo(2), Base.OneTo(3))
+    dom = (Base.OneTo(2), Base.OneTo(3))
+    M = project(raw, cod, dom)
+    @test unproject(M, Val(2)) == raw
+    @test unproject(M, Val(0)) == raw   # split is irrelevant for a dense array
+    @test is_projected(M, raw, Val(2))
 end
 
 @testset "project pads trailing length-1 axes ($T)" for T in elts


### PR DESCRIPTION
## Summary

Adds `unproject(a, ndims_codomain::Val)`, the inverse of `project`. It recovers the dense array that `project` maps `a` from, given the codomain/domain split as a `Val`. The default is `convert(Array, a)`. A backend that changes basis during `project` overloads `unproject` to undo that change, so that `unproject(project(raw, codomain_axes, domain_axes), Val(length(codomain_axes)))` recovers `raw`.

`project` and `tryproject` now run their `is_projected` self-check through `unproject` with the split they were handed, instead of comparing against `convert(Array, dest)`. A backend that stores the projection in the plain dense layout is unaffected. A backend that changes basis in `project` is now checked in the frame the input was given in, so its self-check passes. The two-argument `is_projected` forwards to this split-aware form using the destination's own codomain rank, a new `ndims_codomain` accessor that a `TensorMap` overloads with `numout`.

The TensorKit extension defines `unproject` for `AbstractTensorMap` as `convert(Array, ·)`, which already undoes the domain braiding, guarded by a check that the passed split matches the map's codomain rank.