### PR TITLE
Add `TensorAlgebraTensorKitSectorsExt` for sector `dual`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.17.8"
+version = "0.17.9"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -18,12 +18,14 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [weakdeps]
 Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 TensorKit = "07d1fe3e-3e46-537d-9eac-e9e13d0d4cec"
+TensorKitSectors = "13a9c161-d5da-41f0-bcbd-e1a08ae0647f"
 TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 
 [extensions]
 TensorAlgebraMooncakeExt = "Mooncake"
 TensorAlgebraTensorKitExt = ["TensorKit", "TensorOperations", "VectorInterface"]
+TensorAlgebraTensorKitSectorsExt = "TensorKitSectors"
 TensorAlgebraTensorOperationsExt = "TensorOperations"
 
 [compat]
@@ -35,6 +37,7 @@ Random = "1.10"
 Strided = "2.6"
 StridedViews = "0.5"
 TensorKit = "0.17"
+TensorKitSectors = "0.3.9"
 TensorOperations = "5"
 TupleTools = "1.6"
 VectorInterface = "0.4.8, 0.5"

--- a/ext/TensorAlgebraTensorKitSectorsExt.jl
+++ b/ext/TensorAlgebraTensorKitSectorsExt.jl
@@ -1,0 +1,9 @@
+module TensorAlgebraTensorKitSectorsExt
+
+using TensorAlgebra: TensorAlgebra
+using TensorKitSectors: TensorKitSectors, Sector
+
+# The dual of a sector is its conjugate (charge conjugation), which is TensorKitSectors' own.
+TensorAlgebra.dual(c::Sector) = TensorKitSectors.dual(c)
+
+end

--- a/ext/TensorAlgebraTensorKitSectorsExt.jl
+++ b/ext/TensorAlgebraTensorKitSectorsExt.jl
@@ -3,7 +3,7 @@ module TensorAlgebraTensorKitSectorsExt
 using TensorAlgebra: TensorAlgebra
 using TensorKitSectors: TensorKitSectors, Sector
 
-# The dual of a sector is its conjugate (charge conjugation), which is TensorKitSectors' own.
+# A sector's dual is its conjugate (charge conjugation), forwarded to TensorKitSectors' `dual`.
 TensorAlgebra.dual(c::Sector) = TensorKitSectors.dual(c)
 
 end

--- a/test/test_tensorkitext.jl
+++ b/test/test_tensorkitext.jl
@@ -4,8 +4,8 @@ using StableRNGs: StableRNG
 using TensorAlgebra: TensorAlgebra, contract, matricize, project, projectto!, rand_map,
     randn_map, similar_map, tryflattenlinear, tryproject, unchecked_project, unmatricize,
     zeros_map
-using TensorKit: @tensor, AbstractTensorMap, DiagonalTensorMap, Rep, SU₂, TensorMap, U₁,
-    dim, dual, fuse, isomorphism, randn, reduceddim, space, storagetype, ←, ⊗
+using TensorKit: @tensor, AbstractTensorMap, DiagonalTensorMap, Irrep, Rep, SU₂, TensorMap,
+    U₁, dim, dual, fuse, isomorphism, randn, reduceddim, space, storagetype, ←, ⊗
 using Test: @test, @test_throws, @testset
 
 # A shared bond contracts when it sits in one operand's domain and the other's codomain, i.e.
@@ -331,9 +331,12 @@ using Test: @test, @test_throws, @testset
     end
 end
 
-@testset "dual/isdual on a TensorKit space" begin
+@testset "dual/isdual on TensorKit spaces and sectors" begin
     V = Rep[U₁](0 => 2, 1 => 1)
     @test TensorAlgebra.isdual(V) == false
     @test TensorAlgebra.isdual(dual(V)) == true
     @test TensorAlgebra.dual(V) == dual(V)
+    # A sector's dual is its conjugate.
+    s = Irrep[U₁](1)
+    @test TensorAlgebra.dual(s) == dual(s)
 end


### PR DESCRIPTION
## Summary

Adds a `TensorAlgebraTensorKitSectorsExt` extension defining `dual` on a TensorKitSectors sector (its charge conjugation). This is the sector-level companion to the TensorKit space `dual` and `isdual` overloads added in https://github.com/ITensor/TensorAlgebra.jl/pull/214, keeping all overloads of TensorAlgebra generics on TensorKitSectors types in a dedicated extension. GradedArrays will drop its own sector `dual` in favor of this one.
