### PR TITLE
Compare BiTuple by its flat contents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/bituple.jl
+++ b/src/bituple.jl
@@ -40,10 +40,9 @@ Base.hash(bt::BiTuple, h::UInt) = hash(Tuple(bt), h)
 
 Base.invperm(bt::BiTuple{N1}) where {N1} = BiTuple(invperm(Tuple(bt)), Val(N1))
 
-# An `AbstractArray` whose `axes` is a `BiTuple` reaches a range of generic machinery (Base indexing,
-# Base broadcasting/shape, and the matricize/permute helpers here) that assumes a flat tuple of axes.
-# Index sets, bounds, shapes, and permutations all ignore the codomain/domain split, so flatten the
-# `BiTuple` first. This is the same collapse-to-flat behavior mixed operations fall back to.
+# An `AbstractArray` whose `axes` is a `BiTuple` reaches Base indexing and the matricize/permute
+# helpers here, which assume a flat tuple of axes. Index sets, bounds, and permutations all ignore the
+# codomain/domain split, so flatten the `BiTuple` first.
 Base.LinearIndices(bt::BiTuple) = LinearIndices(Tuple(bt))
 Base.CartesianIndices(bt::BiTuple) = CartesianIndices(Tuple(bt))
 function Base.checkbounds_indices(::Type{Bool}, bt::BiTuple, I::Tuple)
@@ -52,13 +51,6 @@ end
 function Base.PermutedDimsArrays.genperm(bt::BiTuple, perm::NTuple{N, Int}) where {N}
     return Base.PermutedDimsArrays.genperm(Tuple(bt), perm)
 end
-Base.tail(bt::BiTuple) = Base.tail(Tuple(bt))
-Base.front(bt::BiTuple) = Base.front(Tuple(bt))
-Base.lastindex(bt::BiTuple) = Base.lastindex(Tuple(bt))
-Base.safe_tail(bt::BiTuple) = Base.safe_tail(Tuple(bt))
-# In-place `dest .= src` into a `BiTuple`-axed destination carries those axes on the `Broadcasted`;
-# report the flat tuple so the generic element-wise `copyto!` can consume them.
-Base.Broadcast._axes(bc::Base.Broadcast.Broadcasted, axs::BiTuple) = Tuple(axs)
 # A single-argument `map` preserves the split, mapping each block: with one operand there is no
 # ambiguity about which split to keep. (The multi-argument case is the ambiguous one and is left to
 # collapse to the flat tuple.)

--- a/src/bituple.jl
+++ b/src/bituple.jl
@@ -30,9 +30,71 @@ function Base.show(io::IO, bt::BiTuple)
 end
 
 Base.:(==)(a::BiTuple, b::BiTuple) = a.t1 == b.t1 && a.t2 == b.t2
+# Compare flat against a plain tuple, so `axes(a) == (r1, r2)` works when `axes` returns a `BiTuple`.
+Base.:(==)(bt::BiTuple, t::Tuple) = Tuple(bt) == t
+Base.:(==)(t::Tuple, bt::BiTuple) = t == Tuple(bt)
 Base.hash(bt::BiTuple, h::UInt) = hash(bt.t2, hash(bt.t1, hash(:BiTuple, h)))
 
 Base.invperm(bt::BiTuple{N1}) where {N1} = BiTuple(invperm(Tuple(bt)), Val(N1))
+
+# An `AbstractArray` whose `axes` is a `BiTuple` reaches a range of generic machinery (Base indexing,
+# Base broadcasting/shape, and the matricize/permute helpers here) that assumes a flat tuple of axes.
+# Index sets, bounds, shapes, and permutations all ignore the codomain/domain split, so flatten the
+# `BiTuple` first. This is the same collapse-to-flat behavior mixed operations fall back to.
+Base.LinearIndices(bt::BiTuple) = LinearIndices(Tuple(bt))
+Base.CartesianIndices(bt::BiTuple) = CartesianIndices(Tuple(bt))
+function Base.checkbounds_indices(::Type{Bool}, bt::BiTuple, I::Tuple)
+    return Base.checkbounds_indices(Bool, Tuple(bt), I)
+end
+Base.promote_shape(a::BiTuple, b::Tuple) = Base.promote_shape(Tuple(a), b)
+Base.promote_shape(a::Tuple, b::BiTuple) = Base.promote_shape(a, Tuple(b))
+Base.promote_shape(a::BiTuple, b::BiTuple) = Base.promote_shape(Tuple(a), Tuple(b))
+function Base.Broadcast.broadcast_shape(a::BiTuple, shapes...)
+    return Base.Broadcast.broadcast_shape(Tuple(a), shapes...)
+end
+function Base.Broadcast.broadcast_shape(a::Tuple, b::BiTuple, shapes...)
+    return Base.Broadcast.broadcast_shape(a, Tuple(b), shapes...)
+end
+function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::Tuple{})
+    return Base.Broadcast.check_broadcast_shape(Tuple(a), b)
+end
+function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::Tuple)
+    return Base.Broadcast.check_broadcast_shape(Tuple(a), b)
+end
+function Base.Broadcast.check_broadcast_shape(a, b::BiTuple)
+    return Base.Broadcast.check_broadcast_shape(a, Tuple(b))
+end
+function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::BiTuple)
+    return Base.Broadcast.check_broadcast_shape(Tuple(a), Tuple(b))
+end
+function Base._show_nonempty(
+        io::IO,
+        X::AbstractMatrix,
+        prefix::String,
+        drop::Bool,
+        axs::BiTuple
+    )
+    return Base._show_nonempty(io, X, prefix, drop, Tuple(axs))
+end
+function Base.PermutedDimsArrays.genperm(bt::BiTuple, perm::NTuple{N, Int}) where {N}
+    return Base.PermutedDimsArrays.genperm(Tuple(bt), perm)
+end
+Base.tail(bt::BiTuple) = Base.tail(Tuple(bt))
+Base.front(bt::BiTuple) = Base.front(Tuple(bt))
+Base.lastindex(bt::BiTuple) = Base.lastindex(Tuple(bt))
+# A single-argument `map` preserves the split, mapping each block: with one operand there is no
+# ambiguity about which split to keep. (The multi-argument case is the ambiguous one and is left to
+# collapse to the flat tuple.)
+Base.map(f, bt::BiTuple) = BiTuple(map(f, bt.t1), map(f, bt.t2))
+Base.safe_tail(bt::BiTuple) = Base.safe_tail(Tuple(bt))
+Base.rdims(out::Val{N}, bt::BiTuple) where {N} = Base.rdims(out, Tuple(bt))
+Base.offset_if_vec(i::Integer, axs::BiTuple) = Base.offset_if_vec(i, Tuple(axs))
+Base.Broadcast._axes(bc::Base.Broadcast.Broadcasted, axs::BiTuple) = Tuple(axs)
+bipartition_axes(bt::BiTuple, split...) = bipartition_axes(Tuple(bt), split...)
+bipartition(bt::BiTuple, length1::Val) = bipartition(Tuple(bt), length1)
+function bipartition(bt::BiTuple, group1::Tuple, group2::Tuple)
+    return bipartition(Tuple(bt), group1, group2)
+end
 
 """
     bipartition(t::Tuple, length1::Val) -> (t1, t2)

--- a/src/bituple.jl
+++ b/src/bituple.jl
@@ -40,19 +40,6 @@ Base.hash(bt::BiTuple, h::UInt) = hash(Tuple(bt), h)
 
 Base.invperm(bt::BiTuple{N1}) where {N1} = BiTuple(invperm(Tuple(bt)), Val(N1))
 
-# An `AbstractArray` whose `axes` is a `BiTuple` reaches Base indexing and the matricize/permute
-# helpers here, which assume a flat tuple of axes. Index sets, bounds, and permutations all ignore the
-# codomain/domain split, so flatten the `BiTuple` first.
-Base.LinearIndices(bt::BiTuple) = LinearIndices(Tuple(bt))
-Base.CartesianIndices(bt::BiTuple) = CartesianIndices(Tuple(bt))
-# `checkbounds_indices` is Base's extension point for a custom axes container: it dispatches on the
-# axes tuple, so a `BiTuple` (not a `Tuple`) never competes with Base's index-type specializations.
-function Base.checkbounds_indices(::Type{Bool}, bt::BiTuple, I::Tuple)
-    return Base.checkbounds_indices(Bool, Tuple(bt), I)
-end
-function Base.PermutedDimsArrays.genperm(bt::BiTuple, perm::NTuple{N, Int}) where {N}
-    return Base.PermutedDimsArrays.genperm(Tuple(bt), perm)
-end
 # A single-argument `map` preserves the split, mapping each block: with one operand there is no
 # ambiguity about which split to keep. (The multi-argument case is the ambiguous one and is left to
 # collapse to the flat tuple.)

--- a/src/bituple.jl
+++ b/src/bituple.jl
@@ -45,6 +45,8 @@ Base.invperm(bt::BiTuple{N1}) where {N1} = BiTuple(invperm(Tuple(bt)), Val(N1))
 # codomain/domain split, so flatten the `BiTuple` first.
 Base.LinearIndices(bt::BiTuple) = LinearIndices(Tuple(bt))
 Base.CartesianIndices(bt::BiTuple) = CartesianIndices(Tuple(bt))
+# `checkbounds_indices` is Base's extension point for a custom axes container: it dispatches on the
+# axes tuple, so a `BiTuple` (not a `Tuple`) never competes with Base's index-type specializations.
 function Base.checkbounds_indices(::Type{Bool}, bt::BiTuple, I::Tuple)
     return Base.checkbounds_indices(Bool, Tuple(bt), I)
 end

--- a/src/bituple.jl
+++ b/src/bituple.jl
@@ -29,11 +29,14 @@ function Base.show(io::IO, bt::BiTuple)
     return print(io, "BiTuple(", bt.t1, ", ", bt.t2, ")")
 end
 
-Base.:(==)(a::BiTuple, b::BiTuple) = a.t1 == b.t1 && a.t2 == b.t2
-# Compare flat against a plain tuple, so `axes(a) == (r1, r2)` works when `axes` returns a `BiTuple`.
+# Equality ignores the split: it compares the flattened contents, so a `(2, 0)` and a `(1, 1)` split
+# with the same flat entries are equal, and a `BiTuple` equals the plain tuple it flattens to. This
+# mirrors how comparing arrays ignores how they are partitioned into blocks. `hash` matches, hashing
+# the flat form so the equality relation stays hash-consistent.
+Base.:(==)(a::BiTuple, b::BiTuple) = Tuple(a) == Tuple(b)
 Base.:(==)(bt::BiTuple, t::Tuple) = Tuple(bt) == t
 Base.:(==)(t::Tuple, bt::BiTuple) = t == Tuple(bt)
-Base.hash(bt::BiTuple, h::UInt) = hash(bt.t2, hash(bt.t1, hash(:BiTuple, h)))
+Base.hash(bt::BiTuple, h::UInt) = hash(Tuple(bt), h)
 
 Base.invperm(bt::BiTuple{N1}) where {N1} = BiTuple(invperm(Tuple(bt)), Val(N1))
 
@@ -46,50 +49,20 @@ Base.CartesianIndices(bt::BiTuple) = CartesianIndices(Tuple(bt))
 function Base.checkbounds_indices(::Type{Bool}, bt::BiTuple, I::Tuple)
     return Base.checkbounds_indices(Bool, Tuple(bt), I)
 end
-Base.promote_shape(a::BiTuple, b::Tuple) = Base.promote_shape(Tuple(a), b)
-Base.promote_shape(a::Tuple, b::BiTuple) = Base.promote_shape(a, Tuple(b))
-Base.promote_shape(a::BiTuple, b::BiTuple) = Base.promote_shape(Tuple(a), Tuple(b))
-function Base.Broadcast.broadcast_shape(a::BiTuple, shapes...)
-    return Base.Broadcast.broadcast_shape(Tuple(a), shapes...)
-end
-function Base.Broadcast.broadcast_shape(a::Tuple, b::BiTuple, shapes...)
-    return Base.Broadcast.broadcast_shape(a, Tuple(b), shapes...)
-end
-function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::Tuple{})
-    return Base.Broadcast.check_broadcast_shape(Tuple(a), b)
-end
-function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::Tuple)
-    return Base.Broadcast.check_broadcast_shape(Tuple(a), b)
-end
-function Base.Broadcast.check_broadcast_shape(a, b::BiTuple)
-    return Base.Broadcast.check_broadcast_shape(a, Tuple(b))
-end
-function Base.Broadcast.check_broadcast_shape(a::BiTuple, b::BiTuple)
-    return Base.Broadcast.check_broadcast_shape(Tuple(a), Tuple(b))
-end
-function Base._show_nonempty(
-        io::IO,
-        X::AbstractMatrix,
-        prefix::String,
-        drop::Bool,
-        axs::BiTuple
-    )
-    return Base._show_nonempty(io, X, prefix, drop, Tuple(axs))
-end
 function Base.PermutedDimsArrays.genperm(bt::BiTuple, perm::NTuple{N, Int}) where {N}
     return Base.PermutedDimsArrays.genperm(Tuple(bt), perm)
 end
 Base.tail(bt::BiTuple) = Base.tail(Tuple(bt))
 Base.front(bt::BiTuple) = Base.front(Tuple(bt))
 Base.lastindex(bt::BiTuple) = Base.lastindex(Tuple(bt))
+Base.safe_tail(bt::BiTuple) = Base.safe_tail(Tuple(bt))
+# In-place `dest .= src` into a `BiTuple`-axed destination carries those axes on the `Broadcasted`;
+# report the flat tuple so the generic element-wise `copyto!` can consume them.
+Base.Broadcast._axes(bc::Base.Broadcast.Broadcasted, axs::BiTuple) = Tuple(axs)
 # A single-argument `map` preserves the split, mapping each block: with one operand there is no
 # ambiguity about which split to keep. (The multi-argument case is the ambiguous one and is left to
 # collapse to the flat tuple.)
 Base.map(f, bt::BiTuple) = BiTuple(map(f, bt.t1), map(f, bt.t2))
-Base.safe_tail(bt::BiTuple) = Base.safe_tail(Tuple(bt))
-Base.rdims(out::Val{N}, bt::BiTuple) where {N} = Base.rdims(out, Tuple(bt))
-Base.offset_if_vec(i::Integer, axs::BiTuple) = Base.offset_if_vec(i, Tuple(axs))
-Base.Broadcast._axes(bc::Base.Broadcast.Broadcasted, axs::BiTuple) = Tuple(axs)
 bipartition_axes(bt::BiTuple, split...) = bipartition_axes(Tuple(bt), split...)
 bipartition(bt::BiTuple, length1::Val) = bipartition(Tuple(bt), length1)
 function bipartition(bt::BiTuple, group1::Tuple, group2::Tuple)

--- a/src/linearbroadcasted.jl
+++ b/src/linearbroadcasted.jl
@@ -128,11 +128,13 @@ addends(a::AddBroadcasted) = a.args
 # differing shapes), so combine by verifying equality through `axes` (TensorAlgebra's, which
 # works for a non-`AbstractArray` backend like a `TensorMap`) rather than Base's `combine_axes`,
 # which would call `Base.axes`/`Base.size` on the operands. A mismatch (e.g. a half-conjugated
-# `conj.(a) .- b`, whose dualized and non-dualized axes differ) throws here.
+# `conj.(a) .- b`, whose dualized and non-dualized axes differ) throws here. Comparison is on the
+# flat axes (`Tuple`), so operands that agree on the flat legs but differ in a codomain/domain split
+# (`BiTuple`) still combine, matching the split-collapsing result.
 function Base.axes(a::AddBroadcasted)
     axs = map(axes, addends(a))
     ax = first(axs)
-    all(x -> x == ax, axs) ||
+    all(x -> Tuple(x) == Tuple(ax), axs) ||
         throw(DimensionMismatch("linear-combination operands have mismatched axes: $axs"))
     return ax
 end

--- a/src/linearbroadcasted.jl
+++ b/src/linearbroadcasted.jl
@@ -128,13 +128,13 @@ addends(a::AddBroadcasted) = a.args
 # differing shapes), so combine by verifying equality through `axes` (TensorAlgebra's, which
 # works for a non-`AbstractArray` backend like a `TensorMap`) rather than Base's `combine_axes`,
 # which would call `Base.axes`/`Base.size` on the operands. A mismatch (e.g. a half-conjugated
-# `conj.(a) .- b`, whose dualized and non-dualized axes differ) throws here. Comparison is on the
-# flat axes (`Tuple`), so operands that agree on the flat legs but differ in a codomain/domain split
-# (`BiTuple`) still combine, matching the split-collapsing result.
+# `conj.(a) .- b`, whose dualized and non-dualized axes differ) throws here. Axis equality ignores
+# the codomain/domain split, so operands that agree on the flat legs but differ in split still
+# combine, matching the split-collapsing result.
 function Base.axes(a::AddBroadcasted)
     axs = map(axes, addends(a))
     ax = first(axs)
-    all(x -> Tuple(x) == Tuple(ax), axs) ||
+    all(==(ax), axs) ||
         throw(DimensionMismatch("linear-combination operands have mismatched axes: $axs"))
     return ax
 end

--- a/src/matricize.jl
+++ b/src/matricize.jl
@@ -255,7 +255,7 @@ function unmatricizeperm(
         throw(ArgumentError("axes do not match permutation"))
     codomain_axes, domain_axes = bipartition_axes(axes_dest, invbiperm)
     a12 = unmatricize(style, m, codomain_axes, domain_axes)
-    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(axes_dest)))
+    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(invbiperm)))
     return bipermutedims(a12, biperm_dest)
 end
 
@@ -274,7 +274,7 @@ function unmatricizeperm!(
         throw(ArgumentError("destination does not match permutation"))
     codomain_axes, domain_axes = bipartition_axes(axes(a_dest), invbiperm)
     a_perm = unmatricize(style, m, codomain_axes, domain_axes)
-    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(axes(a_dest))))
+    biperm_dest = BiTuple(Tuple(invperm(invbiperm)), Val(length_codomain(invbiperm)))
     return bipermutedims!(a_dest, a_perm, biperm_dest)
 end
 

--- a/test/test_bituple.jl
+++ b/test/test_bituple.jl
@@ -25,19 +25,22 @@ using TestExtras: @constinferred
     # Split constructor: split a flat tuple at the given codomain length.
     @test (@constinferred BiTuple((3, 4, 5, 2, 1), Val(3))) == BiTuple((3, 4, 5), (2, 1))
 
-    # Equality compares the two blocks.
+    # Equality ignores the split, comparing the flattened contents: same flat entries compare equal
+    # even under a different codomain/domain split, the way array equality ignores block partitioning.
     @test BiTuple((1, 2), (3,)) == BiTuple((1, 2), (3,))
-    @test BiTuple((1, 2), (3,)) != BiTuple((1,), (2, 3))
+    @test BiTuple((1, 2), (3,)) == BiTuple((1,), (2, 3))
+    @test BiTuple((1, 2), (3,)) != BiTuple((1, 3), (2,))
 
-    # Equality against a plain tuple compares the flattened form.
+    # A `BiTuple` also equals the plain tuple it flattens to.
     @test BiTuple((1, 2), (3,)) == (1, 2, 3)
     @test (1, 2, 3) == BiTuple((1, 2), (3,))
     @test BiTuple((1, 2), (3,)) != (1, 2)
-    # A plain-tuple comparison ignores the split, unlike a `BiTuple`-vs-`BiTuple` comparison.
-    @test BiTuple((1, 2), (3,)) == (1, 2, 3) == BiTuple((1,), (2, 3))
+    # `hash` matches equality (hashes the flat form).
+    @test hash(BiTuple((1, 2), (3,))) == hash(BiTuple((1,), (2, 3))) == hash((1, 2, 3))
 
-    # Single-argument `map` preserves the split (no ambiguity with one operand).
-    @test (@constinferred map(x -> x + 1, BiTuple((1, 2), (3,)))) == BiTuple((2, 3), (4,))
+    # Single-argument `map` preserves the split (no ambiguity with one operand). Checked with `===`
+    # since `==` ignores the split and so would not catch a collapse to the flat form.
+    @test (@constinferred map(x -> x + 1, BiTuple((1, 2), (3,)))) === BiTuple((2, 3), (4,))
 end
 
 @testset "biperm" begin

--- a/test/test_bituple.jl
+++ b/test/test_bituple.jl
@@ -28,6 +28,16 @@ using TestExtras: @constinferred
     # Equality compares the two blocks.
     @test BiTuple((1, 2), (3,)) == BiTuple((1, 2), (3,))
     @test BiTuple((1, 2), (3,)) != BiTuple((1,), (2, 3))
+
+    # Equality against a plain tuple compares the flattened form.
+    @test BiTuple((1, 2), (3,)) == (1, 2, 3)
+    @test (1, 2, 3) == BiTuple((1, 2), (3,))
+    @test BiTuple((1, 2), (3,)) != (1, 2)
+    # A plain-tuple comparison ignores the split, unlike a `BiTuple`-vs-`BiTuple` comparison.
+    @test BiTuple((1, 2), (3,)) == (1, 2, 3) == BiTuple((1,), (2, 3))
+
+    # Single-argument `map` preserves the split (no ambiguity with one operand).
+    @test (@constinferred map(x -> x + 1, BiTuple((1, 2), (3,)))) == BiTuple((2, 3), (4,))
 end
 
 @testset "biperm" begin


### PR DESCRIPTION
## Summary

Equality and hashing now ignore a `BiTuple`'s bipartitioning, comparing it by its flat contents, alongside a few more `BiTuple` operations like split-preserving `map` and `bipartition`.