### PR TITLE
Check that contracted axes match in contract

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TensorAlgebra"
 uuid = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/contract/allocate_output.jl
+++ b/src/contract/allocate_output.jl
@@ -11,9 +11,25 @@ function check_input(
         a1, perm1_codomain, perm1_domain,
         a2, perm2_codomain, perm2_domain
     )
-    # TODO: FIXME: Check that contracted axes match.
     check_biperm(a1, perm1_codomain, perm1_domain)
     check_biperm(a2, perm2_codomain, perm2_domain)
+    # The contracted axes of `a1` (its domain) pair with the contracted axes of `a2` (its codomain),
+    # and each pair must be a dual pair: `dual(ax1) == ax2`. `dual` falls back to the identity for
+    # plain ranges, so this reduces to `ax1 == ax2` for non-graded arrays.
+    length(perm1_domain) == length(perm2_codomain) || throw(
+        ArgumentError(
+            "Number of contracted axes do not match: `a1` has $(length(perm1_domain)), `a2` has $(length(perm2_codomain))"
+        )
+    )
+    for (i, j) in zip(perm1_domain, perm2_codomain)
+        ax1 = axes(a1, i)
+        ax2 = axes(a2, j)
+        dual(ax1) == ax2 || throw(
+            ArgumentError(
+                "Contracted axes do not match: `axes(a1, $i) = $ax1` and `axes(a2, $j) = $ax2`"
+            )
+        )
+    end
     return nothing
 end
 


### PR DESCRIPTION
## Summary

Add the contracted-axis check that was missing from `check_input` for `contract`: each contracted pair must be a dual pair, `dual(ax1) == ax2` (the identity for plain ranges, so equal axes for non-graded arrays).